### PR TITLE
Ensure asset path

### DIFF
--- a/plugins/templated-asset-webpack-plugin/src/compiled-chunks.js
+++ b/plugins/templated-asset-webpack-plugin/src/compiled-chunks.js
@@ -6,12 +6,19 @@ class CompiledChunks {
       throw new Error("webpack compilation is required to process assets");
 
     if (compilation.chunks && Array.isArray(compilation.chunks)) {
+      const path = ensurePath(compilation);
       const chunks = compilation.chunks.map(chunk => {
         const filename = chunk.files[0];
         return {
           name: chunk.name,
           filename,
-          source: compilation.assets[filename].source()
+          source: compilation.assets[filename].source(),
+          path: path,
+          get url() {
+            return this.path.endsWith("/")
+              ? `${this.path}${this.filename}`
+              : `${this.path}/${this.filename}`;
+          }
         };
       });
 
@@ -33,6 +40,17 @@ class CompiledChunks {
       this.chunks = [];
     }
   }
+}
+
+function ensurePath(compilation) {
+  if (
+    !compilation ||
+    !compilation.mainTemplate ||
+    !compilation.mainTemplate.outputOptions
+  )
+    return "/";
+
+  return compilation.mainTemplate.outputOptions.publicPath || "/";
 }
 
 module.exports = CompiledChunks;

--- a/plugins/templated-asset-webpack-plugin/src/templated-assets.js
+++ b/plugins/templated-asset-webpack-plugin/src/templated-assets.js
@@ -68,7 +68,7 @@ function chunkToAsset(chunk, rule) {
     asset.type.inline = true;
   } else {
     asset = new Asset(name, {
-      content: chunk.filename,
+      content: chunk.url,
       filename: chunk.filename
     });
     asset.type.async = rule.async;

--- a/plugins/templated-asset-webpack-plugin/test/compiled-chunks-init-test.js
+++ b/plugins/templated-asset-webpack-plugin/test/compiled-chunks-init-test.js
@@ -50,10 +50,14 @@ test("map compiled chunks", t => {
   t.is(chunk1.name, expected1.name);
   t.is(chunk1.filename, expected1.files[0]);
   t.is(chunk1.source, compilation.assets[expected1.files[0]].source());
+  t.is(chunk1.path, "/");
+  t.is(chunk1.url, `/${expected1.files[0]}`);
 
   t.is(chunk2.name, expected2.name);
   t.is(chunk2.filename, expected2.files[0]);
   t.is(chunk2.source, compilation.assets[expected2.files[0]].source());
+  t.is(chunk2.path, "/");
+  t.is(chunk2.url, `/${expected2.files[0]}`);
 });
 
 test("include from assets", t => {
@@ -84,7 +88,37 @@ test("include from assets", t => {
   const compiledChunks = new CompiledChunks(compilation).chunks;
   const chunk = compiledChunks[2];
 
-  t.is(compiledChunks.length, 3);  
+  t.is(compiledChunks.length, 3);
   t.is(chunk.filename, "c.js");
   t.is(chunk.source, "contents of c.js");
+});
+
+test("include public path", t => {
+  const compilation = {
+    mainTemplate: {
+      outputOptions: {
+        publicPath: "a public path"
+      }
+    },
+    chunks: [
+      {
+        name: "a",
+        files: ["a.js"]
+      }
+    ],
+    assets: {
+      "a.js": {
+        source: () => "contents of a.js"
+      }
+    }
+  };
+
+  const compiledChunks = new CompiledChunks(compilation).chunks;
+  const chunk = compiledChunks[0];
+
+  t.is(compiledChunks.length, 1);
+  t.is(chunk.filename, "a.js");
+  t.is(chunk.source, "contents of a.js");
+  t.is(chunk.path, "a public path");
+  t.is(chunk.url, "a public path/a.js");
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, "dist"),
-    //publicPath: '/',
+    //publicPath: "https://test-cdn.com/assets",
     filename: "[name].[chunkhash].js"
   },
   module: {


### PR DESCRIPTION
Fixes issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/9 that path/URL was not included for URL assets.

Defaults to prefixing asset with `/` otherwise uses `publicPath`.