### PR TITLE
Output

### DIFF
--- a/example/templated-assets-config.js
+++ b/example/templated-assets-config.js
@@ -13,9 +13,12 @@ module.exports = {
       name: "vendor",
       exclude: /(node_modules)/,
       output: {
-        url: true,
-        async: true,
-        defer: true
+        inline: true
+      },
+      template: (source, filename, callback) => {
+        const updatedSource = `// source from ${filename}
+        ${source}`;
+        callback(updatedSource);
       }
     },
     {

--- a/example/templated-assets-config.js
+++ b/example/templated-assets-config.js
@@ -5,30 +5,35 @@ module.exports = {
     {
       name: ["app"],
       exclude: /(node_modules)/,
-      url: true,
-      defer: true
+      output: {
+        defer: true
+      }
     },
     {
       name: "vendor",
       exclude: /(node_modules)/,
-      url: true,
-      async: true,
-      defer: true
+      output: {
+        url: true,
+        async: true,
+        defer: true
+      }
     },
     {
       name: "manifest",
       exclude: /(node_modules)/,
-      inline: true,
+      output: {
+        inline: true
+      },
       template: path.join(__dirname, "tmpl/inline.tmpl"),
       replace: "##HULAHULA##"
     },
     {
       test: /manifest.json$/,
       exclude: /(node_modules)/,
-      inline: true,
       template: path.join(__dirname, "tmpl/chunk-manifest.tmpl"),
       replace: "##MANIFEST##",
       output: {
+        inline: true,
         prefix: "__",
         extension: "cshtml"
       }

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -87,25 +87,46 @@ class Asset {
   }
 
   process() {
-    return templateReader.read(this.template.path).then(content => {
-      const replacedContent = content.replace(
-        this.template.replace,
-        this.source.content
-      );
 
-      if (content === replacedContent) {
-        throw new Error(
-          `No replacement done in template. Check rule configuration.
+    return new Promise((resolve, reject) => {
+      if (this.template.process) {
+        this.template.process(
+          this.source.content,
+          this.source.filename,
+          (replacedContent) => {
+            resolve({
+              filename: this.file.filename,
+              source: replacedContent,
+              size: replacedContent.length
+            });
+          });
+      } else {
+        return templateReader.read(this.template.path).then(content => {
+          const replacedContent = content.replace(
+            this.template.replace,
+            this.source.content
+          );
+
+          if (content === replacedContent) {
+            throw new Error(
+              `No replacement done in template. Check rule configuration.
         ${content}`
-        );
+            );
+          }
+
+          resolve({
+            filename: this.file.filename,
+            source: replacedContent,
+            size: replacedContent.length
+          });
+        });
       }
 
-      return Promise.resolve({
-        filename: this.file.filename,
-        source: replacedContent,
-        size: replacedContent.length
-      });
+
     });
+
+
+
   }
 }
 

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -87,19 +87,28 @@ class Asset {
   }
 
   process() {
-
     return new Promise((resolve, reject) => {
       if (this.template.process) {
-        this.template.process(
-          this.source.content,
-          this.source.filename,
-          (replacedContent) => {
-            resolve({
-              filename: this.file.filename,
-              source: replacedContent,
-              size: replacedContent.length
-            });
-          });
+        try {
+          this.template.process(
+            this.source.content,
+            this.source.filename,
+            replacedContent => {
+              resolve({
+                filename: this.file.filename,
+                source: replacedContent,
+                size: replacedContent.length
+              });
+            }
+          );
+        } catch (e) {
+          reject(
+            `Templating unsuccessful for:
+          ${JSON.stringify(this.template)}
+          Error:
+          ${e}`
+          );
+        }
       } else {
         return templateReader.read(this.template.path).then(content => {
           const replacedContent = content.replace(
@@ -108,9 +117,8 @@ class Asset {
           );
 
           if (content === replacedContent) {
-            throw new Error(
-              `No replacement done in template. Check rule configuration.
-        ${content}`
+            reject(
+              `No replacement done in template. Check rule configuration.\n${content}`
             );
           }
 
@@ -121,12 +129,7 @@ class Asset {
           });
         });
       }
-
-
     });
-
-
-
   }
 }
 

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -19,8 +19,22 @@ class Asset {
 
     this.file = {
       name: name,
-      prefix: "",
-      extension: "html",
+      _prefix: "",
+      get prefix() {
+        return this._prefix;
+      },
+      set prefix(prefix) {
+        if (typeof prefix !== "string") return;
+        this._prefix = prefix;
+      },
+      _extension: "html",
+      get extension() {
+        return this._extension;
+      },
+      set extension(ext) {
+        if (typeof ext !== "string" || ext === "") return;
+        this._extension = ext;
+      },
       get filename() {
         return mergeFilename(this.prefix, this.name, this.extension);
       }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -21,8 +21,24 @@ class TemplatedAssetWebpackPlugin {
       const chunks = new CompiledChunks(compilation).chunks;
 
       new TemplatedAssets(chunks, this.rules)
-        .process(compilation, callback)
-        .then(() => callback())
+        .process()
+        .then(templatedAssets => {
+          templatedAssets.forEach(asset => {
+            try {
+              compilation.assets[asset.filename] = {
+                source: () => asset.source,
+                size: () => asset.size
+              };
+            } catch (e) {
+              throw new Error(
+                `Failed to include asset ${JSON.stringify(asset)} to compilation.
+            ${e.message}`
+              );
+            }
+          });
+
+          callback();
+        })
         .catch(log);
     });
   }

--- a/lib/rule-set.js
+++ b/lib/rule-set.js
@@ -11,29 +11,29 @@ class RuleSet {
   }
 
   inline() {
-    return this.rules.filter(rule => !!rule.inline);
+    return this.rules.filter(rule => !!rule.output.inline);
   }
 
   url() {
-    return this.rules.filter(rule => !!rule.url);
+    return this.rules.filter(rule => !!rule.output.url);
   }
 
   sync() {
     const rules = this.url();
 
-    return rules.filter(rule => !rule.async && !rule.defer);
+    return rules.filter(rule => !rule.output.async && !rule.output.defer);
   }
 
   async() {
     const rules = this.url();
 
-    return rules.filter(rule => !!rule.async);
+    return rules.filter(rule => !!rule.output.async);
   }
 
   defer() {
     const rules = this.url();
 
-    return rules.filter(rule => !!rule.defer);
+    return rules.filter(rule => !!rule.output.defer);
   }
 }
 
@@ -73,8 +73,11 @@ function flatten(rules) {
 
 function ensureDefaults(rules) {
   return rules.map(rule => {
-    if (!rule.inline) {
-      rule.url = true;
+    if (!rule.output) {
+      rule.output = {};
+    }
+    if (!rule.output.inline) {
+      rule.output.url = true;
     }
     return rule;
   });

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -60,7 +60,7 @@ function chunkToAsset(chunk, rule) {
 
   let asset;
 
-  if (rule.inline) {
+  if (rule.output && rule.output.inline) {
     asset = new Asset(name, {
       content: chunk.source,
       filename: chunk.filename
@@ -71,8 +71,11 @@ function chunkToAsset(chunk, rule) {
       content: chunk.url,
       filename: chunk.filename
     });
-    asset.type.async = rule.async;
-    asset.type.defer = rule.defer;
+
+    if (rule.output) {
+      asset.type.async = rule.output.async;
+      asset.type.defer = rule.output.defer;
+    }
   }
 
   if (rule.replace) {
@@ -83,7 +86,7 @@ function chunkToAsset(chunk, rule) {
     asset.template.path = rule.template;
   }
 
-  if(rule.output) {
+  if (rule.output) {
     asset.file.extension = rule.output.extension || "html";
     asset.file.prefix = rule.output.prefix || "";
   }

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -83,7 +83,19 @@ function chunkToAsset(chunk, rule) {
   }
 
   if (rule.template) {
-    asset.template.path = rule.template;
+    if (typeof rule.template === "function") {
+      asset.template.process = rule.template;
+    } else if (typeof rule.template === "string") {
+      asset.template.path = rule.template;
+    } else if (typeof rule.template === "object") {
+      asset.template = rule.template;
+    } else {
+      throw new Error(`Template ${JSON.stringify(rule.template)} not supported. Must be either of:
+      - path: string
+      - template definition: Object{ path, replace }
+      - template compiler: function(source: string, filename: string, callback: function(updatedSource: string))`);
+    }
+
   }
 
   if (rule.output) {

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -72,7 +72,9 @@ function chunkToAsset(chunk, rule) {
     } else if (typeof rule.template === "string") {
       asset.template.path = rule.template;
     } else if (typeof rule.template === "object") {
-      asset.template = rule.template;
+      asset.template.path = rule.template.path;
+      asset.template.replace = rule.template.replace;
+      //asset.template = rule.template;
     } else {
       throw new Error(`Template ${JSON.stringify(rule.template)} not supported. Must be either of:
       - path: string
@@ -83,8 +85,8 @@ function chunkToAsset(chunk, rule) {
   }
 
   if (rule.output) {
-    asset.file.extension = rule.output.extension || "html";
-    asset.file.prefix = rule.output.prefix || "";
+    asset.file.extension = rule.output.extension;
+    asset.file.prefix = rule.output.prefix;
   }
 
   return asset;

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -15,7 +15,7 @@ class TemplatedAssets {
 
   process() {
     const processes = this.assets.map(asset => asset.process());
-    
+
     return Promise.all(processes);
   }
 }
@@ -55,11 +55,6 @@ function chunkToAsset(chunk, rule) {
       content: chunk.url,
       filename: chunk.filename
     });
-
-    if (rule.output) {
-      asset.type.async = rule.output.async;
-      asset.type.defer = rule.output.defer;
-    }
   }
 
   if (rule.replace) {
@@ -74,19 +69,21 @@ function chunkToAsset(chunk, rule) {
     } else if (typeof rule.template === "object") {
       asset.template.path = rule.template.path;
       asset.template.replace = rule.template.replace;
-      //asset.template = rule.template;
     } else {
-      throw new Error(`Template ${JSON.stringify(rule.template)} not supported. Must be either of:
+      throw new TypeError(
+        `Template ${JSON.stringify(rule.template)} not supported. Must be either of:
       - path: string
-      - template definition: Object{ path, replace }
-      - template compiler: function(source: string, filename: string, callback: function(updatedSource: string))`);
+      - template definition: { path, replace }
+      - template compiler: function(source: string, filename: string, callback: function(updatedSource: string))`
+      );
     }
-
   }
 
   if (rule.output) {
     asset.file.extension = rule.output.extension;
     asset.file.prefix = rule.output.prefix;
+    asset.type.async = rule.output.async;
+    asset.type.defer = rule.output.defer;
   }
 
   return asset;

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -13,26 +13,10 @@ class TemplatedAssets {
     this.assets = mapChunks(chunks, rules);
   }
 
-  process(compilation) {
-    const allProcesses = this.assets.map(asset => {
-      return asset.process().then(templatedAsset => {
-        try {
-          compilation.assets[templatedAsset.filename] = {
-            source: () => templatedAsset.source,
-            size: () => templatedAsset.size
-          };
-        } catch (e) {
-          throw new Error(
-            `Failed to include asset ${JSON.stringify(asset)} to compilation.
-            ${e.message}`
-          );
-        }
-
-        return Promise.resolve();
-      });
-    });
-
-    return Promise.all(allProcesses);
+  process() {
+    const processes = this.assets.map(asset => asset.process());
+    
+    return Promise.all(processes);
   }
 }
 

--- a/test/asset-file-test.js
+++ b/test/asset-file-test.js
@@ -14,8 +14,40 @@ test("default prefix", t => {
   t.is(asset.file.prefix, "");
 });
 
+test("only allow prefix as string", t => {
+  const asset = new Asset("name", { content: "a source", filename: "file.js" });
+
+  asset.file.prefix = 1;
+
+  t.is(asset.file.prefix, "");
+});
+
+test("fallback to no prefix", t => {
+  const asset = new Asset("name", { content: "a source", filename: "file.js" });
+
+  asset.file.prefix = 1;
+
+  t.is(asset.file.prefix, "");
+});
+
 test("default extension", t => {
   const asset = new Asset("name", { content: "a source", filename: "file.js" });
+
+  t.is(asset.file.extension, "html");
+});
+
+test("only allow extension as string", t => {
+  const asset = new Asset("name", { content: "a source", filename: "file.js" });
+
+  asset.file.extension = 1;
+
+  t.is(asset.file.extension, "html");
+});
+
+test("fallback to extension html", t => {
+  const asset = new Asset("name", { content: "a source", filename: "file.js" });
+
+  asset.file.extension = "";
 
   t.is(asset.file.extension, "html");
 });

--- a/test/rule-set-filter-test.js
+++ b/test/rule-set-filter-test.js
@@ -4,12 +4,13 @@ import RuleSet from "../lib/rule-set";
 test("filter inline assets", t => {
   const inlineAsset = {
     name: "chunk1",
-    inline: true
+    output: {
+      inline: true
+    }
   };
 
   const urlAsset = {
-    name: "chunk2",
-    url: true
+    name: "chunk2"
   };
 
   const chunks = new RuleSet([inlineAsset, urlAsset]);
@@ -20,12 +21,16 @@ test("filter inline assets", t => {
 test("filter url assets", t => {
   const inlineAsset = {
     name: "chunk1",
-    inline: true
+    output: {
+      inline: true
+    }
   };
 
   const urlAsset = {
     name: "chunk2",
-    url: true
+    output: {
+      url: true
+    }
   };
 
   const chunks = new RuleSet([inlineAsset, urlAsset]);
@@ -36,37 +41,46 @@ test("filter url assets", t => {
 test("filter sync assets", t => {
   const asyncAsset = {
     name: "chunk1",
-    url: true,
-    async: true
+    output: {
+      url: true,
+      async: true
+    }
   };
 
   const deferredAsset = {
     name: "chunk2",
-    url: true,
-    defer: true
+    output: {
+      url: true,
+      defer: true
+    }
   };
 
   const syncAsset = {
-    name: "chunk3",
-    url: true
+    name: ["chunk3", "chunk4"],
+    output: {
+      url: true
+    }
   };
 
   const chunks = new RuleSet([asyncAsset, deferredAsset, syncAsset]);
 
-  t.deepEqual(chunks.sync(), [syncAsset]);
+  t.deepEqual(chunks.sync(), [{ name: "chunk3", output: { url: true } }, { name: "chunk4", output: { url: true } }]);
 });
 
 test("filter async assets", t => {
   const asyncAsset = {
     name: "chunk1",
-    url: true,
-    async: true
+    output: {
+      async: true
+    }
   };
 
   const deferredAsset = {
     name: "chunk2",
-    url: true,
-    defer: true
+    output: {
+      url: true,
+      defer: true
+    }
   };
 
   const chunks = new RuleSet([asyncAsset, deferredAsset]);
@@ -77,14 +91,18 @@ test("filter async assets", t => {
 test("filter deferred assets", t => {
   const asyncAsset = {
     name: "chunk1",
-    url: true,
-    async: true
+    output: {
+      url: true,
+      async: true
+    }
   };
 
   const deferredAsset = {
     name: "chunk2",
-    url: true,
-    defer: true
+    output: {
+
+      defer: true
+    }
   };
 
   const chunks = new RuleSet([asyncAsset, deferredAsset]);
@@ -95,14 +113,18 @@ test("filter deferred assets", t => {
 test("an asset can be both url and inline", t => {
   const asset1 = {
     name: "chunk1",
-    url: true,
-    inline: true
+    output: {
+      url: true,
+      inline: true
+    }
   };
 
   const asset2 = {
     name: "chunk2",
-    url: true,
-    inline: true
+    output: {
+      url: true,
+      inline: true
+    }
   };
 
   const chunks = [asset1, asset2];

--- a/test/rule-set-init-test.js
+++ b/test/rule-set-init-test.js
@@ -8,18 +8,24 @@ test("default to empty array", t => {
 });
 
 test("treat name string as single chunk", t => {
-  const rules = [
-    {
-      name: "chunk1"
-    },
-    {
-      name: "chunk2"
-    }
-  ];
+  const rules = [{ name: "chunk1" }, { name: "chunk2" }];
 
   const config = new RuleSet(rules);
 
-  t.deepEqual(config.rules, rules);
+  t.deepEqual(config.rules, [
+    {
+      name: "chunk1",
+      output: {
+        url: true
+      }
+    },
+    {
+      name: "chunk2",
+      output: {
+        url: true
+      }
+    }
+  ]);
 });
 
 test("flatten rules when name passed as array", t => {
@@ -31,7 +37,7 @@ test("flatten rules when name passed as array", t => {
 
   const config = new RuleSet(rules);
 
-  t.deepEqual(config.rules, [{ name: "chunk1", url: true }, { name: "chunk2", url: true }]);
+  t.deepEqual(config.rules, [{ name: "chunk1", output: { url: true } }, { name: "chunk2", output: { url: true } }]);
 });
 
 test("throw if no name test nor name", t => {
@@ -74,10 +80,10 @@ test("should prioritize regex over name", t => {
 
   const config = new RuleSet(rules);
 
-  t.deepEqual(config.rules, [{ test: /chunk/, url: true }]);
+  t.deepEqual(config.rules, [{ test: /chunk/, output: { url: true } }]);
 });
 
-test("default to url rule", t => {
+test("default to url rule if no output configured", t => {
   const rules = [
     {
       name: ["chunk1", "chunk2"]
@@ -86,5 +92,47 @@ test("default to url rule", t => {
 
   const config = new RuleSet(rules);
 
-  t.deepEqual(config.rules, [{ name: "chunk1", url: true }, { name: "chunk2", url: true }]);
+  t.deepEqual(config.rules, [{ name: "chunk1", output: { url: true } }, { name: "chunk2", output: { url: true } }]);
+});
+
+test("default to url rule if not inline", t => {
+  const rules = [
+    {
+      name: ["chunk1", "chunk2"]
+    }
+  ];
+
+  const config = new RuleSet(rules);
+
+  t.deepEqual(config.rules, [{ name: "chunk1", output: { url: true } }, { name: "chunk2", output: { url: true } }]);
+});
+
+test("is also url when defer", t => {
+  const rules = [
+    {
+      name: "chunk1",
+      output: {
+        defer: true
+      }
+    }
+  ];
+
+  const config = new RuleSet(rules);
+
+  t.deepEqual(config.rules, [{ name: "chunk1", output: { url: true, defer: true } }]);
+});
+
+test("is also url when async", t => {
+  const rules = [
+    {
+      name: "chunk1",
+      output: {
+        async: true
+      }
+    }
+  ];
+
+  const config = new RuleSet(rules);
+
+  t.deepEqual(config.rules, [{ name: "chunk1", output: { url: true, async: true } }]);
 });


### PR DESCRIPTION
Improve handling for outputting assets (related to issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/6).
- Config option to define own template processor; `template` as `function`.
- Ensure default values for `prefix` and `extension`
- Moved asset type to `output` config