### PR TITLE
Custom source processor args

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
             2
         ],
         "linebreak-style": [
-            "error",
+            "warn",
             "unix"
         ],
         "eol-last": [

--- a/README.md
+++ b/README.md
@@ -53,14 +53,22 @@ test: /match-filename\.js$/
 // template is the path to template or function to process source
 // used for enhancing matching asset(s)
 template: path.join(__dirname, "template-path/my-custom-template.tmpl"),
-template: (asset, callback) => {
+// custom source processor can be set for full control of processing source
+template: (asset, callback, ...args) => {
     // filename: webpack's source file's asset filename
     // source: chunk's source
     // content: what the default processor would have turned the asset's content into
     // url: publicPath (or '/') + filename
     const { filename, source, content, url } = asset;
 
-    const updatedSource = myCustomSourceProcessor(/* do your thing */);
+    // access rule specific args 
+    const arguments = args;
+
+    // process
+    const updatedSource = myCustomSourceProcessor();
+
+    // notify templated-assets-webpack-plugin when done
+    // pass updated source back to output as asset
     callback(updatedSource);
 },
 // template can also be defined as object, with path and value to look for and replace
@@ -75,7 +83,10 @@ template: {
 // * default for inlined assets is `##SOURCE`
 replace: "***IMPORTANT-STUFF***"
 
-// configure how to enhance the asset with `output` (or combine with own source processor)
+// pass custom arguments, accessible in custom source processor
+args: []
+
+// configure how to enhance the asset with `output`
 output: {
     // url asset is default if other not configured. Takes the file name and combines with webpack's config `publicPath`
     url: true,

--- a/README.md
+++ b/README.md
@@ -53,8 +53,14 @@ test: /match-filename\.js$/
 // template is the path to template or function to process source
 // used for enhancing matching asset(s)
 template: path.join(__dirname, "template-path/my-custom-template.tmpl"),
-template: (source, filename, callback) => {
-    const updatedSource = myCustomSourceProcessor();
+template: (asset, callback) => {
+    // filename: webpack's source file's asset filename
+    // source: chunk's source
+    // content: what the default processor would have turned the asset's content into
+    // url: publicPath (or '/') + filename
+    const { filename, source, content, url } = asset;
+
+    const updatedSource = myCustomSourceProcessor(/* do your thing */);
     callback(updatedSource);
 },
 // template can also be defined as object, with path and value to look for and replace

--- a/example/templated-assets-config.js
+++ b/example/templated-assets-config.js
@@ -9,13 +9,11 @@ module.exports = {
       }
     },
     {
-      name: "vendor",
-      output: {
-        inline: true
-      },
-      template: (source, filename, callback) => {
-        const updatedSource = `// source from ${filename}
-        ${source}`;
+      test: /vendor.*\.js$/,
+      template: (asset, callback) => {
+        const updatedSource = `// source from ${asset.filename} to ${asset.url}
+        // default templating would have resulted in ${asset.content}
+        ${asset.source}`;
         callback(updatedSource);
       }
     },

--- a/example/templated-assets-config.js
+++ b/example/templated-assets-config.js
@@ -10,12 +10,19 @@ module.exports = {
     },
     {
       test: /vendor.*\.js$/,
-      template: (asset, callback) => {
-        const updatedSource = `// source from ${asset.filename} to ${asset.url}
+      // in supported version of Node.js use:
+      // template: (asset, callback, ...args) => {
+      template: function customSourceProcessor(asset, callback) {
+        const args = arguments.length > 2 &&
+          Array.prototype.slice.call(arguments, 2);
+
+        const updatedSource = `// built with webpack and ${args.join("-")}
+        // source from ${asset.filename} to ${asset.url}
         // default templating would have resulted in ${asset.content}
         ${asset.source}`;
         callback(updatedSource);
-      }
+      },
+      args: ["templated", "assets", "webpack", "plugin"]
     },
     {
       name: "manifest",

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, "dist"),
-    //publicPath: "https://test-cdn.com/assets",
+    publicPath: "https://test-cdn.com/assets",
     filename: "[name].[chunkhash].js"
   },
   module: {

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -103,46 +103,58 @@ class Asset {
   process() {
     return new Promise((resolve, reject) => {
       if (this.template.process) {
-        try {
-          this.template.process(
-            this.source,
-            replacedContent => {
-              resolve({
-                filename: this.file.filename,
-                source: replacedContent,
-                size: replacedContent.length
-              });
-            }
-          );
-        } catch (e) {
-          reject(
-            `Templating unsuccessful for:
+        this.processExternal(resolve, reject);
+      } else {
+        return this.processTemplate(resolve, reject);
+      }
+    });
+  }
+
+  processTemplate(resolve, reject) {
+    return templateReader.read(this.template.path).then(content => {
+      const replacedContent = content.replace(
+        this.template.replace,
+        this.source.content
+      );
+
+      if (content === replacedContent) {
+        reject(
+          `No replacement done in template. Check rule configuration.\n${content}`
+        );
+      }
+
+      resolve({
+        filename: this.file.filename,
+        source: replacedContent,
+        size: replacedContent.length
+      });
+    });
+  }
+
+  processExternal(resolve, reject) {
+    try {
+      const output = replacedContent => {
+        resolve({
+          filename: this.file.filename,
+          source: replacedContent,
+          size: replacedContent.length
+        });
+      };
+
+      const args = Array.isArray(this.source.args) ? this.source.args : [];
+
+      this.template.process.apply(
+        this.template.process,
+        [this.source, output].concat(args)
+      );
+    } catch (e) {
+      reject(
+        `Templating unsuccessful for:
           ${JSON.stringify(this.template)}
           Error:
           ${e}`
-          );
-        }
-      } else {
-        return templateReader.read(this.template.path).then(content => {
-          const replacedContent = content.replace(
-            this.template.replace,
-            this.source.content
-          );
-
-          if (content === replacedContent) {
-            reject(
-              `No replacement done in template. Check rule configuration.\n${content}`
-            );
-          }
-
-          resolve({
-            filename: this.file.filename,
-            source: replacedContent,
-            size: replacedContent.length
-          });
-        });
-      }
-    });
+      );
+    }
   }
 }
 

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -105,8 +105,7 @@ class Asset {
       if (this.template.process) {
         try {
           this.template.process(
-            this.source.content,
-            this.source.filename,
+            this.source,
             replacedContent => {
               resolve({
                 filename: this.file.filename,

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -46,7 +46,8 @@ function chunkToAsset(chunk, rule) {
     content: rule.output && rule.output.inline ? chunk.source : chunk.url,
     url: chunk.url,
     source: chunk.source,
-    filename: chunk.filename
+    filename: chunk.filename,
+    args: rule.args
   });
 
   if (rule.output) {

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -42,19 +42,22 @@ function chunksToAssets(chunks, rules) {
 function chunkToAsset(chunk, rule) {
   const name = chunk.name || chunk.filename;
 
-  let asset;
+  const asset = new Asset(name, {
+    content: rule.output && rule.output.inline ? chunk.source : chunk.url,
+    url: chunk.url,
+    source: chunk.source,
+    filename: chunk.filename
+  });
 
-  if (rule.output && rule.output.inline) {
-    asset = new Asset(name, {
-      content: chunk.source,
-      filename: chunk.filename
-    });
-    asset.type.inline = true;
-  } else {
-    asset = new Asset(name, {
-      content: chunk.url,
-      filename: chunk.filename
-    });
+  if (rule.output) {
+    asset.file.extension = rule.output.extension;
+    asset.file.prefix = rule.output.prefix;
+    asset.type.async = rule.output.async;
+    asset.type.defer = rule.output.defer;
+
+    if (rule.output.inline) {
+      asset.type.inline = true;
+    }
   }
 
   if (rule.replace) {
@@ -77,13 +80,6 @@ function chunkToAsset(chunk, rule) {
       - template compiler: function(source: string, filename: string, callback: function(updatedSource: string))`
       );
     }
-  }
-
-  if (rule.output) {
-    asset.file.extension = rule.output.extension;
-    asset.file.prefix = rule.output.prefix;
-    asset.type.async = rule.output.async;
-    asset.type.defer = rule.output.defer;
   }
 
   return asset;


### PR DESCRIPTION
When custom source processor is being used, more information is likely needed than source and filename, brought up in issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/14.

Following is now passed to custom source processor
* `Asset`, including what the default template processor would have used as source
* Rule specific `args` (if exists, accessible in `arguments` object)