### PR TITLE
Multiple output paths for assets matching rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ output: {
     prefix: "__",  // default: no prefix
     // if server-side templating engine's used, the asset's file extension can be controlled 
     extension: "txt", // default: html
-    // specify path to output folder for assets matching rule
-    path: "a/directory", // default: ""
+    // specify folder(s) as output path for assets matching rule
+    path: "a/directory", // default: no custom output directory
+    path: ["first/output/directory", "create/copy/here"], // for duplicate output
     // configure if assets matching rule should be included in webpack's output
     // if `output.path` used, duplicate assets are created if emitAsset is true
     emitAsset: false // default: true

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -110,7 +110,6 @@ class Asset {
             "Specify output path(s); string or Array (for multiple copies)"
           );
 
-        const repeatingSlash = /\/+$/;
         if (path === "") {
           this._path = [];
         } else if (Array.isArray(path)) {
@@ -153,10 +152,7 @@ class Asset {
         );
       }
 
-      if (this.output.path) {
-        const filePath = `${this.output.path}/${this.file.filename}`;
-        io.write(filePath, replacedContent);
-      }
+      write(this.output.path, this.file.filename, replacedContent);
 
       resolve({
         emitAsset: this.output.emitAsset,
@@ -170,10 +166,7 @@ class Asset {
   processExternal(resolve, reject) {
     try {
       const output = replacedContent => {
-        if (this.output.path) {
-          const filePath = `${this.output.path}/${this.file.filename}`;
-          io.write(filePath, replacedContent);
-        }
+        write(this.output.path, this.file.filename, replacedContent);
 
         resolve({
           emitAsset: this.output.emitAsset,
@@ -196,6 +189,14 @@ class Asset {
           ${e}`
       );
     }
+  }
+}
+
+function write(paths, filename, content) {
+  if (!paths.useDefault) {
+    paths
+      .map(path => `${path}/${filename}`)
+      .forEach(filePath => io.write(filePath, content));
   }
 }
 

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -96,16 +96,28 @@ class Asset {
     };
 
     this.output = {
-      _path: "",
+      _path: [],
+      get useDefault() {
+        return this._path.length === 0;
+      },
       get path() {
         return this._path;
       },
       set path(path) {
         if (!path) return;
-        if (typeof path !== "string")
-          throw new TypeError("Specify path to template (as string)");
+        if (typeof path !== "string" && !Array.isArray(path))
+          throw new TypeError(
+            "Specify output path(s); string or Array (for multiple copies)"
+          );
 
-        this._path = path.replace(/\/+$/, "");
+        const repeatingSlash = /\/+$/;
+        if (path === "") {
+          this._path = [];
+        } else if (Array.isArray(path)) {
+          this._path = path.map(trimRepeatingSlash);
+        } else {
+          this._path = [trimRepeatingSlash(path)];
+        }
       },
       _emitAsset: true,
       get emitAsset() {
@@ -193,6 +205,11 @@ function mergeFilename(prefix, name, extension) {
 
 function singleDot(value) {
   return `.${value}`.replace(/(\.)(?=\.*\1)/g, "");
+}
+
+function trimRepeatingSlash(value) {
+  const repeatingSlash = /\/+$/;
+  return value.replace(repeatingSlash, "");
 }
 
 module.exports = Asset;

--- a/test/asset-output-test.js
+++ b/test/asset-output-test.js
@@ -1,14 +1,41 @@
 import test from "ava";
 import Asset from "../lib/asset";
 
+test("use default", t => {
+  const name = "a-name";
+  const asset = new Asset(name, { content: "a source", filename: "file.js" });
+
+  t.is(asset.output.useDefault, true);
+});
+
+test("use custom", t => {
+  const name = "a-name";
+  const asset = new Asset(name, { content: "a source", filename: "file.js" });
+
+  asset.output.path = "a/path";
+
+  t.is(asset.output.useDefault, false);
+});
+
 test("default to no custom output location", t => {
   const name = "a-name";
   const asset = new Asset(name, { content: "a source", filename: "file.js" });
 
-  t.is(asset.output.path, "");
+  t.deepEqual(asset.output.path, []);
+  t.is(asset.output.useDefault, true);
 });
 
-test("output as string", t => {
+test("when blank input, fallback to default output location", t => {
+  const name = "a-name";
+  const asset = new Asset(name, { content: "a source", filename: "file.js" });
+
+  asset.output.path = "";
+
+  t.deepEqual(asset.output.path, []);
+  t.is(asset.output.useDefault, true);
+});
+
+test("path as string or Array", t => {
   const name = "a-name";
   const asset = new Asset(name, { content: "a source", filename: "file.js" });
 
@@ -19,27 +46,40 @@ test("output as string", t => {
     TypeError
   );
 
-  t.is(error.message, "Specify path to template (as string)");
+  t.is(
+    error.message,
+    "Specify output path(s); string or Array (for multiple copies)"
+  );
 });
 
-test("overrideable output path", t => {
+test("overrideable single output path", t => {
   const name = "a-name";
   const asset = new Asset(name, { content: "a source", filename: "file.js" });
 
   asset.output.path = "a/path";
 
-  t.is(asset.output._path, "a/path");
-  t.is(asset.output.path, "a/path");
+  t.deepEqual(asset.output._path, ["a/path"]);
+  t.deepEqual(asset.output.path, ["a/path"]);
+});
+
+test("overrideable multiple output paths", t => {
+  const name = "a-name";
+  const asset = new Asset(name, { content: "a source", filename: "file.js" });
+
+  asset.output.path = ["a/path", "another/path"];
+
+  t.deepEqual(asset.output._path, ["a/path", "another/path"]);
+  t.deepEqual(asset.output.path, ["a/path", "another/path"]);
 });
 
 test("asset ends without slash", t => {
   const name = "a-name";
   const asset = new Asset(name, { content: "a source", filename: "file.js" });
 
-  asset.output.path = "a/path///";
+  asset.output.path = ["a/path///", "another/path//"];
 
-  t.is(asset.output._path, "a/path");
-  t.is(asset.output.path, "a/path");
+  t.deepEqual(asset.output._path, ["a/path", "another/path"]);
+  t.deepEqual(asset.output.path, ["a/path", "another/path"]);
 });
 
 test("default output asset", t => {

--- a/test/asset-process-external-write-multiple-test.js
+++ b/test/asset-process-external-write-multiple-test.js
@@ -1,0 +1,31 @@
+import test from "ava";
+import Asset from "../lib/asset";
+import io from "../lib/file-io";
+
+test.cb("should output custom processed asset", t => {
+  t.plan(4);
+
+  const output1 = (path, content) => {
+    t.is(path, "a/path/a-name.html");
+    t.is(content, "source modified");
+  };
+
+  const output2 = (path, content) => {
+    t.is(path, "another/path/a-name.html");
+    t.is(content, "source modified");
+    t.end();
+  };
+
+  io.write = (path, content) => {
+    if (path.startsWith("a/path")) output1(path, content);
+    if (path.startsWith("another/path")) output2(path, content);
+  };
+
+  const asset = new Asset("a-name", { content: "source", filename: "file.js" });
+  asset.template.process = (source, callback) => {
+    callback("source modified");
+  };
+  asset.output.path = ["a/path", "another/path"];
+
+  asset.process();
+});

--- a/test/asset-process-template-write-multiple.js
+++ b/test/asset-process-template-write-multiple.js
@@ -1,0 +1,30 @@
+import test from "ava";
+import Asset from "../lib/asset";
+import io from "../lib/file-io";
+
+test.cb("should process multiple copies", t => {
+  t.plan(4);
+
+  io.read = () => Promise.resolve("mocked template ##URL##");
+
+  const output1 = (path, content) => {
+    t.is(path, "a/path/a-name.html");
+    t.is(content, "mocked template source");
+  };
+
+  const output2 = (path, content) => {
+    t.is(path, "another/path/a-name.html");
+    t.is(content, "mocked template source");
+    t.end();
+  };
+
+  io.write = (path, content) => {
+    if (path.startsWith("a/path")) output1(path, content);
+    if (path.startsWith("another/path")) output2(path, content);
+  };
+
+  const asset = new Asset("a-name", { content: "source", filename: "file.js" });
+  asset.output.path = ["a/path", "another/path"];
+
+  asset.process();
+});

--- a/test/templated-assets-init-test.js
+++ b/test/templated-assets-init-test.js
@@ -134,5 +134,5 @@ test("map chunks", t => {
   t.is(asset3.file.prefix, "__");
   t.is(asset3.type.inline, true);
   t.is(asset3.output.emitAsset, false);
-  t.is(asset3.output.path, "output/path");
+  t.deepEqual(asset3.output.path, ["output/path"]);
 });


### PR DESCRIPTION
For usecases when duplicates are needed (issue: https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/30), rules' output option now supports multiple `path` to be set; `["a/directory", "a/location/for/duplicate"]`.