### PR TITLE
Chunk exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ To create templated assets, a range of rules can be defined (at least one must b
 name: "match-this-chunk-name",
 name: ["chunk-name", "other-chunk-name"],
 // if regex used for rule, filenames for assets will be matched instead of chunk names
-test: /match-filename\.js$/ 
+test: /match-filename\.js$/,
+// if exclude pattern given, matching filenames will be excluded from being templated
+exclude: /^[0-9]+\./ // exclude async chunks
 
 // template is the path to template or function to process source
 // used for enhancing matching asset(s)

--- a/lib/chunk-matcher.js
+++ b/lib/chunk-matcher.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function keep(chunks, rules) {
   if (!chunks || !Array.isArray(chunks)) return [];
   if (!rules || !Array.isArray(rules)) return [];
@@ -26,13 +28,19 @@ function chunkFilter(rules, chunk) {
 }
 
 function matches(rule, chunk) {
-  if (rule.name) {
-    if (rule.name === chunk.name) return true;
-  } else if (rule.test) {
-    if (rule.test.test(chunk.filename)) return true;
+  let match = false;
+
+  if (rule.name && rule.name === chunk.name) {
+    match = true;
+  } else if (rule.test && rule.test.test(chunk.filename)) {
+    match = true;
   }
 
-  return false;
+  if (rule.exclude && rule.exclude.test(chunk.filename)) {
+    match = false;
+  }
+
+  return match;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "templated-assets-webpack-plugin",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "webpack plugin for generating templated assets, suitable for i.e. server-side rendering.",
   "main": "index.js",
   "dependencies": {},

--- a/test/chunk-matcher-exclude-test.js
+++ b/test/chunk-matcher-exclude-test.js
@@ -1,0 +1,68 @@
+import test from "ava";
+import chunkMatcher from "../lib/chunk-matcher";
+
+test("exclude chunks by regex", t => {
+  const chunks = [
+    {
+      filename: "match.json"
+    },
+    {
+      filename: "match.js"
+    }
+  ];
+
+  const assets = chunkMatcher.keep(chunks, [
+    {
+      test: /^match/,
+      exclude: /\.json$/
+    }
+  ]);
+
+  t.is(assets.length, 1);
+  t.is(assets[0].filename, "match.js");
+});
+
+test("exclude async chunks", t => {
+  const chunks = [
+    {
+      name: "chunk",
+      filename: "chunk.js"
+    },
+    {
+      name: "chunk",
+      filename: "0.async-chunk.js"
+    }
+  ];
+
+  const assets = chunkMatcher.keep(chunks, [
+    {
+      name: "chunk",
+      exclude: /^[0-9]+\./
+    }
+  ]);
+
+  t.is(assets.length, 1);
+  t.is(assets[0].filename, "chunk.js");
+});
+
+test("only exclude if matches regex", t => {
+  const chunks = [
+    {
+      filename: "match.json"
+    },
+    {
+      filename: "match.js"
+    }
+  ];
+
+  const assets = chunkMatcher.keep(chunks, [
+    {
+      test: /^match/,
+      exclude: /non-match/
+    }
+  ]);
+
+  t.is(assets.length, 2);
+  t.is(assets[0].filename, "match.json");
+  t.is(assets[1].filename, "match.js");
+});


### PR DESCRIPTION
To prevent including unnecessary chunks, exclusion patterns can now be given (issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/7). These can be combined with matching chunk name and/or chunk filename.