### PR TITLE
Use webpack module RawSource instead of tracking asset size

### DIFF
--- a/lib/asset.js
+++ b/lib/asset.js
@@ -157,8 +157,7 @@ class Asset {
       resolve({
         emitAsset: this.output.emitAsset,
         filename: this.file.filename,
-        source: replacedContent,
-        size: replacedContent.length
+        source: replacedContent
       });
     });
   }
@@ -171,8 +170,7 @@ class Asset {
         resolve({
           emitAsset: this.output.emitAsset,
           filename: this.file.filename,
-          source: replacedContent,
-          size: replacedContent.length
+          source: replacedContent
         });
       };
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const RawSource = require("webpack-sources").RawSource;
+
 const log = require("./logger").log;
 const RuleSet = require("./rule-set");
 const CompiledChunks = require("./compiled-chunks");
@@ -31,10 +33,7 @@ class Plugin {
           templatedAssets.forEach(asset => {
             if (!asset.emitAsset) return;
             try {
-              compilation.assets[asset.filename] = {
-                source: () => asset.source,
-                size: () => asset.size
-              };
+              compilation.assets[asset.filename] = new RawSource(asset.source);
             } catch (e) {
               throw new Error(
                 `Failed to include asset ${JSON.stringify(asset)} to compilation.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "webpack plugin for generating templated assets, suitable for i.e. server-side rendering.",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "webpack-sources": "^1.0.2"
+  },
   "devDependencies": {
     "ava": "^0.19.0",
     "babel-core": "^6.24.0",
@@ -63,10 +65,22 @@
   },
   "nyc": {
     "watermarks": {
-      "lines": [80, 95],
-      "functions": [80, 95],
-      "branches": [80, 95],
-      "statements": [80, 95]
+      "lines": [
+        80,
+        95
+      ],
+      "functions": [
+        80,
+        95
+      ],
+      "branches": [
+        80,
+        95
+      ],
+      "statements": [
+        80,
+        95
+      ]
     }
   }
 }

--- a/test/asset-process-external-test.js
+++ b/test/asset-process-external-test.js
@@ -24,7 +24,6 @@ test("should pass args to custom source processor", async t => {
   const expected = "a-b-c";
   t.is(result.filename, `${name}.html`);
   t.is(result.source, expected);
-  t.is(result.size, expected.length);
   t.is(result.emitAsset, true);
 });
 
@@ -42,7 +41,6 @@ test("should notify to not emit asset", async t => {
   const expected = "source modified";
   t.is(result.filename, `${name}.html`);
   t.is(result.source, expected);
-  t.is(result.size, expected.length);
   t.is(result.emitAsset, false);
 });
 

--- a/test/asset-process-template-test.js
+++ b/test/asset-process-template-test.js
@@ -14,7 +14,6 @@ test("should replace template's content", async t => {
   const expected = "mocked template source";
   t.is(result.filename, `${name}.html`);
   t.is(result.source, expected);
-  t.is(result.size, expected.length);
   t.is(result.emitAsset, true);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3987,6 +3987,10 @@ source-list-map@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.1.tgz#1a33ac210ca144d1e561f906ebccab5669ff4cb4"
 
+source-list-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
 source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
@@ -4006,6 +4010,10 @@ source-map@^0.4.4, source-map@~0.4.1:
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spawn-wrap@1.2.4:
   version "1.2.4"
@@ -4432,6 +4440,13 @@ webpack-sources@^0.2.3:
   dependencies:
     source-list-map "^1.1.1"
     source-map "~0.5.3"
+
+webpack-sources@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.2.tgz#d0148ec083b3b5ccef1035a6b3ec16442983b27a"
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
 
 webpack@^2.3.3:
   version "2.3.3"


### PR DESCRIPTION
PR address issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/39.

Internally tracking size of asset is not needed when using `require("webpack-sources").RawSource`.