### PR TITLE
Option to specify header/footer for template

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,13 @@
             "always"
         ],
         "no-console": 0,
-        "no-unused-vars": 1
+        "no-unused-vars": 1,
+        "prefer-const": [
+            "error", {
+                "destructuring": "any",
+                "ignoreReadBeforeAssign": false
+            }
+        ]
     },
     "globals": {
         "__dirname": true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ template: path.join(__dirname, "template-path/my-custom-template.tmpl"),
 // or template can be defined as object
 template: {
     path, // path to template
-    replace // replace value in template with asset's content (see replace property for default values)
+    replace, // replace value in template with asset's content (see replace property for default values)
+    header, // prepend header to templated asset (string|function)
+    footer // append footer to templated asset (string|function)
 },
 // or for full control of processing, you can process asset's source by specifying a function 
 template: (asset, callback, ...args) => {

--- a/example/templated-assets-config.js
+++ b/example/templated-assets-config.js
@@ -9,7 +9,11 @@ module.exports = {
       }
     },
     {
-      test: /\.css$/
+      test: /\.css$/,
+      template: {
+        header: "<!-- css starts here -->\n",
+        footer: () => "<!-- css ends here -->"
+      }
     },
     {
       test: /vendor.*\.js$/,

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -184,7 +184,7 @@ class Asset {
         );
       }
 
-      let enclosedContent = append(
+      const enclosedContent = append(
         prepend(replacedContent, this.template.header),
         this.template.footer
       );
@@ -243,11 +243,11 @@ class Asset {
 }
 
 function prepend(content, header) {
-  return !!header ? `${header}${content}` : content;
+  return header ? `${header}${content}` : content;
 }
 
 function append(content, footer) {
-  return !!footer ? `${content}${footer}` : content;
+  return footer ? `${content}${footer}` : content;
 }
 
 function write(paths, filename, content) {

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -102,6 +102,24 @@ class Asset {
           );
 
         this._replace = replace;
+      },
+      _header: "",
+      get header() {
+        return typeof this._header === "function"
+          ? this._header()
+          : this._header;
+      },
+      set header(header) {
+        this._header = header;
+      },
+      _footer: "",
+      get footer() {
+        return typeof this._footer === "function"
+          ? this._footer()
+          : this._footer;
+      },
+      set footer(footer) {
+        this._footer = footer;
       }
     };
 
@@ -166,12 +184,17 @@ class Asset {
         );
       }
 
-      write(this.output.path, this.file.filename, replacedContent);
+      let enclosedContent = append(
+        prepend(replacedContent, this.template.header),
+        this.template.footer
+      );
+
+      write(this.output.path, this.file.filename, enclosedContent);
 
       resolve({
         emitAsset: this.output.emitAsset,
         filename: this.file.filename,
-        source: replacedContent
+        source: enclosedContent
       });
     });
   }
@@ -217,6 +240,14 @@ class Asset {
       }
     });
   }
+}
+
+function prepend(content, header) {
+  return !!header ? `${header}${content}` : content;
+}
+
+function append(content, footer) {
+  return !!footer ? `${content}${footer}` : content;
 }
 
 function write(paths, filename, content) {

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -77,8 +77,8 @@ class Asset {
         return `${dir}/sync.tmpl`;
       },
       set path(path) {
-        if (!path || typeof path !== "string")
-          throw new Error("Specify path to template (as string)");
+        if (!!path && typeof path !== "string")
+          throw new TypeError("Specify path to template (string)");
 
         this._path = path;
       },

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -71,6 +71,8 @@ function chunkToAsset(chunk, rule) {
       asset.template.path = rule.template;
     } else if (typeof rule.template === "object") {
       asset.template.path = rule.template.path;
+      asset.template.header = rule.template.header;
+      asset.template.footer = rule.template.footer;
       if (rule.template.replace) {
         asset.template.replace = rule.template.replace;
       }

--- a/test/asset-process-template-test.js
+++ b/test/asset-process-template-test.js
@@ -46,3 +46,73 @@ test("should notify to not emit asset", async t => {
 
   t.is(result.emitAsset, false);
 });
+
+test("apply template header", async t => {
+  io.read = () => Promise.resolve("mocked template ##URL##");
+
+  const name = "a-name";
+  const filename = "file.js";
+  const assetSource = new AssetSource(filename, "source");
+  const asset = new Asset(name, assetSource, `/${filename}`);
+
+  const header = "a-header";
+  asset.template.header = header;
+
+  const result = await asset.process();
+
+  const expected = `${header}mocked template /${filename}`;
+  t.is(result.source, expected);
+});
+
+test("apply template header function", async t => {
+  io.read = () => Promise.resolve("mocked template ##URL##");
+
+  const name = "a-name";
+  const filename = "file.js";
+  const assetSource = new AssetSource(filename, "source");
+  const asset = new Asset(name, assetSource, `/${filename}`);
+
+  const header = "a-header";
+  asset.template.header = () => header;
+
+  const result = await asset.process();
+
+  const expected = `${header}mocked template /${filename}`;
+  t.is(result.source, expected);
+});
+
+test("apply template footer", async t => {
+  io.read = () => Promise.resolve("mocked template ##URL##");
+
+  const name = "a-name";
+  const filename = "file.js";
+  const assetSource = new AssetSource(filename, "source");
+  const asset = new Asset(name, assetSource, `/${filename}`);
+
+  const footer = "a-footer";
+  asset.template.footer = footer;
+
+  const result = await asset.process();
+
+  const expected = `mocked template /${filename}${footer}`;
+  t.is(result.source, expected);
+});
+
+test("apply template footer function", async t => {
+  io.read = () => Promise.resolve("mocked template ##URL##");
+
+  const name = "a-name";
+  const filename = "file.js";
+  const assetSource = new AssetSource(filename, "source");
+  const asset = new Asset(name, assetSource, `/${filename}`);
+
+  const footer = "a-footer";
+  asset.template.footer = () => footer;
+
+  const result = await asset.process();
+
+  const expected = `mocked template /${filename}${footer}`;
+  t.is(result.filename, `${name}.html`);
+  t.is(result.source, expected);
+  t.is(result.emitAsset, true);
+});

--- a/test/asset-template-test.js
+++ b/test/asset-template-test.js
@@ -36,7 +36,7 @@ test("throw when template path not specified as string", t => {
     Error
   );
 
-  t.is(error.message, "Specify path to template (as string)");
+  t.is(error.message, "Specify path to template (string)");
 });
 
 test("default template is replaced", t => {

--- a/test/templated-assets-init-test.js
+++ b/test/templated-assets-init-test.js
@@ -82,7 +82,9 @@ test("map chunks", t => {
       name: "named-asset",
       replace: "##NAME##",
       template: {
-        path: "named-asset-path"
+        path: "named-asset-path",
+        header: "a-header",
+        footer: "a-footer"
       },
       args: [1, 2, 3]
     }
@@ -127,6 +129,9 @@ test("map chunks", t => {
 
   const asset2 = templatedAssets.assets[1];
   t.is(asset2.type.sync, true);
+  t.is(asset2.template.replace.test("##NAME##"), true);
+  t.is(asset2.template.header, "a-header");
+  t.is(asset2.template.footer, "a-footer");
   t.is(asset2.template.replace.test("##NAME##"), true);
   t.deepEqual(asset2.args, [1, 2, 3]);
 


### PR DESCRIPTION
- Added capability to enclose template in header and footer (issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/38).
- Also, made setting custom template path optional. Use built-in templates when custom not specified.
- Configured eslint to fail if `var`/`let` been used where `const` is prefered.
