### PR TITLE
What over how in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,138 +1,166 @@
 # Templated Assets Webpack Plugin
 
-[templated-assets-webpack-plugin](https://www.npmjs.com/package/templated-assets-webpack-plugin) is a webpack plugin for augmenting webpack generated assets. This is achieved by using built-in or custom templates to extend webpack's output. The plugin also supports running custom source processors (i.e. using a template engine).
-
-## Use cases
-- Generate partial views, for server-side rendering assets outputted by webpack (like referencing scripts and/or inlining assets)
-- Enhancing webpack's compiled assets, i.e. inlining webpack's manifest and/or chunk manifest (`manifest.json`)
-- Use template literals or template engine to augment webpack's assets 
+[templated-assets-webpack-plugin](https://www.npmjs.com/package/templated-assets-webpack-plugin) is a webpack plugin for simplifying the process required to use webpack's compiled assets with web frameworks. webpack's output can be wrapped to create assets suitable for rendering server-side. This is achieved by using predefined templates (built-in or custom) to extend webpack's output.
 
 [![Build Status](https://travis-ci.org/jouni-kantola/templated-assets-webpack-plugin.svg?branch=master)](https://travis-ci.org/jouni-kantola/templated-assets-webpack-plugin)
 
-## Usage
-`templated-assets-webpack-plugin` takes a set of rules for defining how to template assets. Out of the box, comes templates for script tags. The default templates are for inlining scripts or referencing with URL (including async/defer).
+## Use cases
+The plugin aims to be unopinionated and cover a broad range of use cases, but specifically the following:
+* When hashing webpack's assets, the plugin enables server-side referencing or inlining assets built by webpack. Build partial views with JavaScript or CSS content for a web framework (like ASP.NET or Express). 
+* Wrap webpack built assets in HTML tags, i.e. inline CSS for critical path rendering or simplify including webpack's runtime (AKA manifest) server-side.
+* Augment generation of webpack's assets with a template engine.
+
+```javascript
+// webpack.config.js
+const TemplatedAssetsWebpackPlugin = require("templated-assets-webpack-plugin");
+
+module.exports = {
+  /* ... */
+  plugins: [
+    // manifest created
+    new webpack.optimize.CommonsChunkPlugin({
+      name: ["manifest"],
+      minChunks: Infinity
+    }),
+    new TemplatedAssetsWebpackPlugin({
+      rules: [
+        {
+          // inline manifest in script tag
+          name: "manifest",
+          output: {
+            inline: true
+          }
+        }
+      ]
+    })
+  ]
+};
+```
 
 ## Installation
 - `npm install templated-assets-webpack-plugin --save-dev`
 - `yarn add templated-assets-webpack-plugin --dev`
 
 ## Configuration
-webpack's assets can either be targeted by name or filename. Below is an example for inlining webpack's runtime (commonly called 'manifest').
-
-### webpack.config.js
-```javascript
-const TemplatedAssetsWebpackPlugin = require("templated-assets-webpack-plugin");
-
-const templatedAssetsConfig = {
-    rules: [
-        {
-            // output webpack's runtime inlined in script tag
-            name: "manifest",
-            output: {
-                inline: true
-            }
-        }
-    ]
-}
-
-module.exports = {
-  /* webpack config values */
-  plugins: [
-    // templated-assets-webpack-plugin match chunk name
-    new webpack.optimize.CommonsChunkPlugin({
-      name: ["manifest"],
-      minChunks: Infinity
-    }),
-    new TemplatedAssetsWebpackPlugin(templatedAssetsConfig)
-  ]
-};
-```
+`templated-assets-webpack-plugin` takes a set of rules for defining how to wrap assets. Out of the box, comes templates for inlining or referencing scripts and styles.
 
 ### Rules
-To create templated assets, a *range of rules* can be defined (at least one must be configured). Every rule is a separate object, but can be *used to match and template multiple assets*. Below follow descriptions for the properties that can be specified for the plugin's rules.
+Processing webpack's assets is enabled by specifying `rules` for mapping asset(s) to a template. Rules are given as arguments when initializing `templated-assets-webpack-plugin`. Each rule can *match and template multiple assets*. Next section describes rule options.
+
+### Match assets
+Use `name` or `test` to match assets to be templated by name or filename. One of them is required to be specified. If both are used, `test` takes precedence. Use `exclude` if you want to filter out webpack built assets from being processed.
+
+| Property  | Type         | Default value  | Description             |
+|-----------|--------------|----------------|-------------------------|
+| `name`    | string/Array | N/A            | Match asset by name     |
+| `test`    | RegExp       | N/A            | Match asset by filename |
+| `exclude` | RegExp       | none           | Filter out assets       |
 
 ```javascript
-// set either name (string || [string, string, ...]) OR test (/regex/)
+// match asset name (string|Array)
 name: "match-this-chunk-name",
 name: ["chunk-name", "other-chunk-name"],
-// if regex used for rule, asset filenames will be matched instead of names
+// or match asset filename (regex)
 test: /match-filename\.js$/,
-// filenames matching exclude pattern will be excluded from being templated
-exclude: /^[0-9]+\./ // example: exclude async chunks
+// exclude (regex) assets from being templated; tests filename
+exclude: /^[0-9]+\./
+```
 
-// augment matching assets
-// the template property is used to specify path to a custom template
+### Define templates
+The plugin's shipped with built-in templates for linking or inlining scripts and styles. Therefor, the `template` property isn't required, but enables customization. If the template property is specified as function, you're given full control of how to process assets. `template` can also be defined as an object, which adds functionality for adding header and/or footer.
+
+| Property   | Type                   | Default value          | Description                      |
+|------------|------------------------|------------------------|----------------------------------|
+| `template` | string/object/function | script/link tag        | Template for wrapping asset      |
+| `replace`  | string/RegExp          | `##URL##`/`##SOURCE##` | Placeholder for asset url/source |
+| `args`     | Array                  | []                     | Extra args to template function  |
+
+```javascript
+// path to custom template (string)
+// not required, defaults to built-in templates
 template: path.join(__dirname, "template-path/my-custom-template.tmpl"),
-// or template can be defined as object
+// or granually define template specifics
 template: {
-    path, // path to template
-    replace, // replace value in template with asset's content (see replace property for default values)
-    header, // prepend header to templated asset (string|function)
-    footer // append footer to templated asset (string|function)
+  // path to custom template (string)
+  // not required, defaults to built-in templates
+  path: path.join(__dirname, "template-path/my-custom-template.tmpl"),
+  // find placeholder/content in template for subsitution with asset url/source (regex|string)
+  // not required, defaults to ##URL## or ##SOURCE##
+  replace: "***REPLACE-THIS***",
+  // if specified, prepends header to templated asset (string|function)
+  header: "<!-- PREPEND THIS -->",
+  // if specified, appends footer to templated asset (string|function)
+  footer: () => "<!-- APPEND THIS -->"
 },
-// or for full control of processing, you can process asset's source by specifying a function 
+// or full control of templating asset (function)
 template: (asset, callback, ...args) => {
-    // argument `asset` includes:
-    // filename: source asset filename
-    // source: chunk's source
-    // content: plugin's built-in processor's result
-    // url: publicPath (or '/') with filename
-    const { filename, source, content, url } = asset;
+  const {
+    // source asset filename
+    filename,
+    // asset source
+    source,
+    // built-in processor's result
+    content,
+    // url: url to asset, including publicPath (or "/")
+    url
+  } = asset;
 
-    // custom rule specific args 
-    const arguments = args;
+  // rule specific args
+  const ruleArgs = args;
 
-    // example LoC for processing the asset
-    const updatedSource = myCustomSourceProcessor();
+  // example asset templating
+  const templatedAsset = processCustom();
 
-    // when done, pass updated asset back to be included in webpack's output
-    callback(updatedSource);
-}
+  // notify done with templated asset (string)
+  callback(templatedAsset);
+},
+// if specified, arguments to custom templating function
+args: [],
+// find placeholder/content in template for subsitution with asset url/source (regex|string)
+// not required, defaults to ##URL## or ##SOURCE##
+// note: if `template.replace` specified, template object's `replace` takes precedence
+replace: "***REPLACE-THIS***"
+```
 
-// pass custom arguments (accessible in custom source processor)
-args: []
+### Templated asset output
+When templated assets are created its contents can either contain the source of a webpack compiled asset or an URL to the asset. Which used is defined in the `output` property. To align with web frameworks, the templated asset's filename can be updated with `prefix` and `extension`. If needed, custom output locations can be set.
 
-// when custom template specified, configure what to search and replace
-// * default for assets referenced by URL is `##URL`
-// * default for inlined assets is `##SOURCE`
-replace: "***IMPORTANT-STUFF***"
+| Property | Type   | Default value                         | Description                |
+|----------|--------|---------------------------------------|----------------------------|
+| `output` | object | Partial HTML files with URL reference | Asset type and file output |
 
-// configure how to output the augmented asset
-// sync/async/defer/async+defer are included with the plugin
+```javascript
+// configure templated asset output
+// not required, default included in webpack's output with assets referenced by URL
 output: {
-    // output type URL is default, if other not configured
-    url: true, // asset's filename combined with webpack's `publicPath`
-    async: false, // like url, including async attribute
-    defer: false, // like url, including defer attribute
-    // inline asset's source, instead of referencing asset by URL
-    inline: false,
-    // configure if assets should be included in webpack's default output
-    emitAsset: false, // default: true
-    // prefix output templated asset's filename
-    prefix: "__",  // default: no prefix
-    // control templated asset's file extension (i.e. for server-side template engine)
-    extension: "cshtml", // default: html
-    // specify output folder(s) for generated assets
-    // duplicate assets created if `emitAsset` is true
-    path: "a/directory", // default: webpack's output directory
-    path: ["first/output/directory", "create/copy/here"] // duplicate output
+  // URL referencing a webpack asset (including `publicPath`)
+  url: true,
+  // include async attribute (default: false)
+  async: false,
+  // include defer attribute (default: false)
+  defer: false,
+  // inline asset's source (default: false)
+  // takes precedence over reference by URL
+  inline: false,
+  // include templated asset in webpack's default output (default: true)
+  emitAsset: false,
+  // prefix templated asset's filename (default: no prefix)
+  prefix: "__",
+  // templated asset's file extension (default: html)
+  extension: "cshtml",
+  // output folder(s) for templated assets
+  // duplicate asset created if `emitAsset` is true
+  path: "a/directory",
+   // output to multiple folders
+  path: ["first/output/directory", "create/copy/here"]
 }
 ```
 
-## Example configuration
-Included in the repo is an [example build](https://github.com/jouni-kantola/templated-assets-webpack-plugin/blob/master/example/webpack.config.js) where various [configuration options](https://github.com/jouni-kantola/templated-assets-webpack-plugin/blob/master/example/templated-assets-config.js) are used.
+## Plugin examples
+To get up to speed quicker with plugin configuration, take a look at an [example build](https://github.com/jouni-kantola/templated-assets-webpack-plugin/blob/master/example/webpack.config.js) where various [rules](https://github.com/jouni-kantola/templated-assets-webpack-plugin/blob/master/example/templated-assets-config.js) are used.
 
-The example build is triggered by executing `npm run example`. The build will i.e. output the file `__manifest.json.cshtml`, which is a templated asset for `chunk-manifest-webpack-plugin`'s resulting `manifest.json`.
+Try the build by executing `npm run example`. Included are rules for e.g. inlining webpack's runtime and custom templating for webpack's chunk manifest.
 
-```html
-<script type="text/javascript">window.webpackManifest={"0":"0.04df1ad6b72d121fd6ab.js","1":"1.652fb163ed4c79d993d0.js","2":"2.3a556c55f764acccb23a.js"}</script>
-```
-
-Custom template used:
-```html
-<script type="text/javascript">window.webpackManifest=##MANIFEST##</script>
-```
-
-## Feedback and/or updates
+## Feedback
 * For feedback, bugs or change requests, please use [Issues](https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues).
 * For direct contact, tweet [@jouni_kantola](https://twitter.com/jouni_kantola).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "templated-assets-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "webpack plugin for generating templated assets, suitable for i.e. server-side rendering.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
* Updated `package.json` version to `v1.1.0` preparing for release
* Readme's use cases updated and tried to be more focused on what (over how) in config instructions (issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/37)