### PR TITLE
Enclose templated content in EOL's

### DIFF
--- a/example/templated-assets-config.js
+++ b/example/templated-assets-config.js
@@ -11,7 +11,7 @@ module.exports = {
     {
       test: /\.css$/,
       template: {
-        header: "<!-- css starts here -->\n",
+        header: "<!-- css starts here -->",
         footer: () => "<!-- css ends here -->"
       }
     },

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -186,9 +186,11 @@ ${content}`
         );
       }
 
+      const header = this.template.header && `${this.template.header}\n`;
+      const footer = this.template.footer && `\n${this.template.footer}`;
       const enclosedContent = str.append(
-        str.prepend(replacedContent, this.template.header),
-        this.template.footer
+        str.prepend(replacedContent, header),
+        footer
       );
 
       write(this.output.path, this.file.filename, enclosedContent);

--- a/test/asset-process-template-test.js
+++ b/test/asset-process-template-test.js
@@ -1,7 +1,8 @@
 import test from "ava";
+import { EOL } from "os";
+
 import Asset from "../lib/asset";
 import AssetSource from "../lib/asset-source";
-
 import io from "../lib/file-io";
 
 test("should replace template's content", async t => {
@@ -60,7 +61,7 @@ test("apply template header", async t => {
 
   const result = await asset.process();
 
-  const expected = `${header}mocked template /${filename}`;
+  const expected = `${header}${EOL}mocked template /${filename}`;
   t.is(result.source, expected);
 });
 
@@ -77,7 +78,7 @@ test("apply template header function", async t => {
 
   const result = await asset.process();
 
-  const expected = `${header}mocked template /${filename}`;
+  const expected = `${header}${EOL}mocked template /${filename}`;
   t.is(result.source, expected);
 });
 
@@ -94,7 +95,7 @@ test("apply template footer", async t => {
 
   const result = await asset.process();
 
-  const expected = `mocked template /${filename}${footer}`;
+  const expected = `mocked template /${filename}${EOL}${footer}`;
   t.is(result.source, expected);
 });
 
@@ -111,7 +112,7 @@ test("apply template footer function", async t => {
 
   const result = await asset.process();
 
-  const expected = `mocked template /${filename}${footer}`;
+  const expected = `mocked template /${filename}${EOL}${footer}`;
   t.is(result.source, expected);
 });
 
@@ -130,6 +131,6 @@ test("apply template header and footer", async t => {
 
   const result = await asset.process();
 
-  const expected = `${header}mocked template /${filename}${footer}`;
+  const expected = `${header}${EOL}mocked template /${filename}${EOL}${footer}`;
   t.is(result.source, expected);
 });


### PR DESCRIPTION
As mentioned in issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/54 a template required to be formatted with newlines to not append/prepend header/footer on same line as content. This is fixed in this PR.
