### PR TITLE
Extract Rule class

### DIFF
--- a/lib/rule-set.js
+++ b/lib/rule-set.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const is = require("is");
-const matches = require("./chunk-matcher").matches;
+
+const Rule = require("./rule");
 
 class RuleSet {
   constructor(rules) {
@@ -38,7 +39,7 @@ class RuleSet {
         )}`
       );
 
-    return this.rules.find(rule => matches(rule, chunk));
+    return this.rules.find(rule => rule.match(chunk));
   }
 }
 
@@ -83,16 +84,8 @@ const flatten = rules => {
   }, []);
 };
 
-const ensureDefaults = rule => {
-  if (!rule.output) {
-    rule.output = {};
-  }
-  if (!rule.output.inline) {
-    rule.output.url = true;
-  }
-  return rule;
-};
-
 exports.from = rules => {
-  return new RuleSet(isValid(rules) ? flatten(rules).map(ensureDefaults) : []);
+  return new RuleSet(
+    isValid(rules) ? flatten(rules).map(rule => new Rule(rule)) : []
+  );
 };

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,0 +1,22 @@
+"use strict";
+
+class Rule {
+  constructor(rule) {
+    this.output = rule.output || {};
+    if (!this.output.inline) {
+      this.output.url = true;
+    }
+    Object.assign(this, rule);
+  }
+
+  match(chunk) {
+    if (this.exclude && this.exclude.test(chunk.filename)) return false;
+
+    return (
+      (this.test && this.test.test(chunk.filename)) ||
+      (this.name && this.name === chunk.name)
+    );
+  }
+}
+
+module.exports = Rule;

--- a/test/rule-set-filter-test.js
+++ b/test/rule-set-filter-test.js
@@ -1,5 +1,7 @@
 import test from "ava";
+
 import RuleSet from "../lib/rule-set";
+import Rule from "../lib/rule";
 
 test("filter inline assets", t => {
   const inlineAsset = {
@@ -15,7 +17,7 @@ test("filter inline assets", t => {
 
   const ruleSet = RuleSet.from([inlineAsset, urlAsset]);
 
-  t.deepEqual(ruleSet.inline().rules, [inlineAsset]);
+  t.deepEqual(ruleSet.inline().rules, [new Rule(inlineAsset)]);
 });
 
 test("filter url assets", t => {
@@ -35,7 +37,7 @@ test("filter url assets", t => {
 
   const ruleSet = RuleSet.from([inlineAsset, urlAsset]);
 
-  t.deepEqual(ruleSet.url().rules, [urlAsset]);
+  t.deepEqual(ruleSet.url().rules, [new Rule(urlAsset)]);
 });
 
 test("filter sync assets", t => {
@@ -65,8 +67,8 @@ test("filter sync assets", t => {
   const ruleSet = RuleSet.from([asyncAsset, deferredAsset, syncAsset]);
 
   t.deepEqual(ruleSet.sync().rules, [
-    { name: "chunk3", output: { url: true } },
-    { name: "chunk4", output: { url: true } }
+    new Rule({ name: "chunk3", output: { url: true } }),
+    new Rule({ name: "chunk4", output: { url: true } })
   ]);
 });
 
@@ -88,7 +90,7 @@ test("filter async assets", t => {
 
   const ruleSet = RuleSet.from([asyncAsset, deferredAsset]);
 
-  t.deepEqual(ruleSet.async().rules, [asyncAsset]);
+  t.deepEqual(ruleSet.async().rules, [new Rule(asyncAsset)]);
 });
 
 test("filter deferred assets", t => {
@@ -109,30 +111,29 @@ test("filter deferred assets", t => {
 
   const ruleSet = RuleSet.from([asyncAsset, deferredAsset]);
 
-  t.deepEqual(ruleSet.defer().rules, [deferredAsset]);
+  t.deepEqual(ruleSet.defer().rules, [new Rule(deferredAsset)]);
 });
 
 test("an asset can be both url and inline", t => {
-  const asset1 = {
-    name: "chunk1",
-    output: {
-      url: true,
-      inline: true
+  const rules = [
+    {
+      name: "chunk1",
+      output: {
+        url: true,
+        inline: true
+      }
+    },
+    {
+      name: "chunk2",
+      output: {
+        url: true,
+        inline: true
+      }
     }
-  };
-
-  const asset2 = {
-    name: "chunk2",
-    output: {
-      url: true,
-      inline: true
-    }
-  };
-
-  const rules = [asset1, asset2];
+  ];
 
   const ruleSet = RuleSet.from(rules);
 
-  t.deepEqual(ruleSet.url().rules, rules);
-  t.deepEqual(ruleSet.inline().rules, rules);
+  t.deepEqual(ruleSet.url().rules, rules.map(rule => new Rule(rule)));
+  t.deepEqual(ruleSet.inline().rules, rules.map(rule => new Rule(rule)));
 });

--- a/test/rule-set-init-test.js
+++ b/test/rule-set-init-test.js
@@ -1,5 +1,6 @@
 import test from "ava";
 import RuleSet from "../lib/rule-set";
+import Rule from "../lib/rule";
 
 test("default to empty array", t => {
   t.deepEqual(RuleSet.from().rules, []);
@@ -11,18 +12,18 @@ test("treat name string as single chunk", t => {
   const ruleSet = RuleSet.from(rules);
 
   t.deepEqual(ruleSet.rules, [
-    {
+    new Rule({
       name: "chunk1",
       output: {
         url: true
       }
-    },
-    {
+    }),
+    new Rule({
       name: "chunk2",
       output: {
         url: true
       }
-    }
+    })
   ]);
 });
 
@@ -36,8 +37,8 @@ test("flatten rules when name passed as array", t => {
   const ruleSet = RuleSet.from(rules);
 
   t.deepEqual(ruleSet.rules, [
-    { name: "chunk1", output: { url: true } },
-    { name: "chunk2", output: { url: true } }
+    new Rule({ name: "chunk1", output: { url: true } }),
+    new Rule({ name: "chunk2", output: { url: true } })
   ]);
 });
 
@@ -86,7 +87,7 @@ test("should prioritize regex over name", t => {
   ];
 
   t.deepEqual(RuleSet.from(rules).rules, [
-    { test: /chunk/, output: { url: true } }
+    new Rule({ test: /chunk/, output: { url: true } })
   ]);
 });
 
@@ -100,8 +101,8 @@ test("default to url rule if no output configured", t => {
   const actual = RuleSet.from(rules).rules;
 
   t.deepEqual(actual, [
-    { name: "chunk1", output: { url: true } },
-    { name: "chunk2", output: { url: true } }
+    new Rule({ name: "chunk1", output: { url: true } }),
+    new Rule({ name: "chunk2", output: { url: true } })
   ]);
 });
 
@@ -113,8 +114,8 @@ test("default to url rule if not inline", t => {
   ];
 
   t.deepEqual(RuleSet.from(rules).rules, [
-    { name: "chunk1", output: { url: true } },
-    { name: "chunk2", output: { url: true } }
+    new Rule({ name: "chunk1", output: { url: true } }),
+    new Rule({ name: "chunk2", output: { url: true } })
   ]);
 });
 
@@ -129,7 +130,7 @@ test("is also url when defer", t => {
   ];
 
   t.deepEqual(RuleSet.from(rules).rules, [
-    { name: "chunk1", output: { url: true, defer: true } }
+    new Rule({ name: "chunk1", output: { url: true, defer: true } })
   ]);
 });
 
@@ -144,6 +145,6 @@ test("is also url when async", t => {
   ];
 
   t.deepEqual(RuleSet.from(rules).rules, [
-    { name: "chunk1", output: { url: true, async: true } }
+    new Rule({ name: "chunk1", output: { url: true, async: true } })
   ]);
 });


### PR DESCRIPTION
Use types internally in plugin. Rule(s) are used extensively, so start moving rule specific logic into extracted class `Rule`.