### PR TITLE
Override templated asset name

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ replace: "***REPLACE-THIS***"
 ```
 
 ### Templated asset output
-When templated assets are created its contents can either contain the source of a webpack compiled asset or an URL to the asset. Which used is defined in the `output` property. To align with web frameworks, the templated asset's filename can be updated with `prefix` and `extension`. If needed, custom output locations can be set.
+When templated assets are created its contents can either contain the source of a webpack compiled asset or an URL to the asset. Which used is defined in the `output` property. To align with frameworks for server rendering, the generated templated asset's filename can be updated with `name`, `prefix` and `extension`. If needed, custom output locations can be set.
 
 | Property | Type   | Default value                         | Description                |
 |----------|--------|---------------------------------------|----------------------------|
@@ -133,6 +133,14 @@ When templated assets are created its contents can either contain the source of 
 // configure templated asset output
 // not required, default included in webpack's output with assets referenced by URL
 output: {
+  // assign name to templated asset (default: chunk name/filename)
+  // useful when chunk name has not been assigned in webpack
+  name: "a-templated-asset",
+  name: (defaultName) => defaultName.split(".")[0],
+  // prefix templated asset's filename (default: no prefix)
+  prefix: "__",
+  // templated asset's file extension (default: html)
+  extension: "cshtml",
   // URL referencing a webpack asset (including `publicPath`)
   url: true,
   // include async attribute (default: false)
@@ -144,10 +152,6 @@ output: {
   inline: false,
   // include templated asset in webpack's default output (default: true)
   emitAsset: false,
-  // prefix templated asset's filename (default: no prefix)
-  prefix: "__",
-  // templated asset's file extension (default: html)
-  extension: "cshtml",
   // output folder(s) for templated assets
   // duplicate asset created if `emitAsset` is true
   path: "a/directory",

--- a/example/templated-assets-config.js
+++ b/example/templated-assets-config.js
@@ -13,6 +13,9 @@ module.exports = {
       template: {
         header: "<!-- css starts here -->",
         footer: () => "<!-- css ends here -->"
+      },
+      output: {
+        name: defaultName => defaultName.split(".")[0]
       }
     },
     {
@@ -46,9 +49,10 @@ module.exports = {
       template: path.join(__dirname, "tmpl/chunk-manifest.tmpl"),
       replace: "##MANIFEST##",
       output: {
-        inline: true,
+        name: "chunk-manifest",
+        extension: "cshtml",
         prefix: "__",
-        extension: "cshtml"
+        inline: true
       }
     }
   ]

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
       append: `\n//# sourceMappingURL=${publicPath}/[url]\n`
     }),
     new ExtractTextPlugin({
-      filename: "styles.css",
+      filename: "styles.[contenthash].css",
       allChunks: true
     }),
     new TemplatedAssetWebpackPlugin(templatedAssetsConfig)

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const is = require("is");
+
 const chunkMatcher = require("./chunk-matcher");
 const AssetSource = require("./asset-source");
 const Asset = require("./asset");
@@ -41,9 +43,9 @@ function chunksToAssets(chunks, ruleSet) {
 }
 
 function chunkToAsset(chunk, rule) {
-  const name = chunk.name || chunk.filename;
   const assetSource = new AssetSource(chunk.filename, chunk.source);
 
+  const name = nameAsset(chunk, rule);
   const asset = new Asset(name, assetSource, chunk.url, rule.args);
 
   if (rule.output) {
@@ -85,6 +87,18 @@ function chunkToAsset(chunk, rule) {
   }
 
   return asset;
+}
+
+function nameAsset(chunk, rule) {
+  const defaultName = chunk.name || chunk.filename;
+
+  if (rule.output) {
+    if (is.string(rule.output.name)) return rule.output.name;
+
+    if (is.function(rule.output.name)) return rule.output.name(defaultName);
+  }
+
+  return defaultName;
 }
 
 module.exports = TemplatedAssets;

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -8,9 +8,9 @@ const Asset = require("./asset");
 
 class TemplatedAssets {
   constructor(chunks, ruleSet) {
-    if (!Array.isArray(chunks))
+    if (!is.array(chunks))
       throw new TypeError("Chunks must be specified to map chunks with rules.");
-    if (!(typeof ruleSet === "object"))
+    if (!is.object(ruleSet))
       throw new TypeError("Rules must be specified to map rules with chunks.");
 
     this.assets = mapChunks(chunks, ruleSet);
@@ -63,11 +63,11 @@ function chunkToAsset(chunk, rule) {
   }
 
   if (rule.template) {
-    if (typeof rule.template === "function") {
+    if (is.function(rule.template)) {
       asset.template.process = rule.template;
-    } else if (typeof rule.template === "string") {
+    } else if (is.string(rule.template)) {
       asset.template.path = rule.template;
-    } else if (typeof rule.template === "object") {
+    } else if (is.object(rule.template)) {
       asset.template.path = rule.template.path;
       asset.template.header = rule.template.header;
       asset.template.footer = rule.template.footer;

--- a/lib/templated-assets.js
+++ b/lib/templated-assets.js
@@ -95,7 +95,15 @@ function nameAsset(chunk, rule) {
   if (rule.output) {
     if (is.string(rule.output.name)) return rule.output.name;
 
-    if (is.function(rule.output.name)) return rule.output.name(defaultName);
+    if (is.function(rule.output.name)) {
+      const name = rule.output.name(defaultName);
+      if (!is.string(name))
+        throw new TypeError(
+          "Rule's asset naming function must return name (string)"
+        );
+
+      return name;
+    }
   }
 
   return defaultName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "templated-assets-webpack-plugin",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "webpack plugin for creating assets to be used with server rendered web frameworks.",
   "main": "index.js",
   "dependencies": {

--- a/test/templated-assets-init-test.js
+++ b/test/templated-assets-init-test.js
@@ -73,14 +73,26 @@ test("map chunks", t => {
       }
     },
     {
-      name: "named-asset",
+      name: "chunk-name",
       replace: "##NAME##",
       template: {
-        path: "named-asset-path",
+        path: "chunk-name-path",
         header: "a-header",
         footer: "a-footer"
       },
       args: [1, 2, 3]
+    },
+    {
+      name: "chunk-name-to-override",
+      output: {
+        name: "overriden-chunk-name"
+      }
+    },
+    {
+      name: "another-chunk-name-to-override",
+      output: {
+        name: defaultName => defaultName.split("-")[0]
+      }
     }
   ]);
 
@@ -102,16 +114,26 @@ test("map chunks", t => {
       source: "non-match-source"
     },
     {
-      name: "named-asset",
+      name: "chunk-name",
       filename: "na.js",
       url: "/na.js",
-      source: "named-asset-source"
+      source: "chunk-name-source"
+    },
+    {
+      name: "chunk-name-to-override",
+      url: "/na.js",
+      filename: "na.js"
+    },
+    {
+      name: "another-chunk-name-to-override",
+      url: "/na.js",
+      filename: "na.js"
     }
   ];
 
   const templatedAssets = new TemplatedAssets(chunks, rules);
 
-  t.is(templatedAssets.assets.length, 3);
+  t.is(templatedAssets.assets.length, 5);
 
   const asset1 = templatedAssets.assets[0];
   t.is(asset1.file.extension, "html");
@@ -127,12 +149,19 @@ test("map chunks", t => {
   t.is(asset2.template.header, "a-header");
   t.is(asset2.template.footer, "a-footer");
   t.is(asset2.template.replace.test("##NAME##"), true);
+  t.is(asset2.file.filename, "chunk-name.html");
   t.deepEqual(asset2.args, [1, 2, 3]);
 
   const asset3 = templatedAssets.assets[2];
-  t.is(asset3.file.extension, "txt");
-  t.is(asset3.file.prefix, "__");
-  t.is(asset3.type.inline, true);
-  t.is(asset3.output.emitAsset, false);
-  t.deepEqual(asset3.output.path, ["output/path"]);
+  t.is(asset3.file.filename, "overriden-chunk-name.html");
+
+  const asset4 = templatedAssets.assets[3];
+  t.is(asset4.file.filename, "another.html");
+
+  const asset5 = templatedAssets.assets[4];
+  t.is(asset5.file.extension, "txt");
+  t.is(asset5.file.prefix, "__");
+  t.is(asset5.type.inline, true);
+  t.is(asset5.output.emitAsset, false);
+  t.deepEqual(asset5.output.path, ["output/path"]);
 });


### PR DESCRIPTION
PR address issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/58.

For complete control of naming of an asset, now `output.name` can also be configured. This is useful when an asset has been added directly to `compilation.assets` (the asset will not have name, only filename). This is even more useful when assets with hashed filenames are added to `compilation.assets`, because that will prevent predictability in the resulting templated asset's filename.

As rules can match multiple assets, a `string` property for naming will result in the same name for multiple templated assets. Using `string` to configure `name` is suitable when only one chunk is matched by a rule (if even needed). When the filename of a rule isn't predictable, `name` can be configured as a function.
