### PR TITLE
Windows/*nix newline fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+tab_width = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,7 @@
         "no-console": 0,
         "no-unused-vars": 1,
         "prefer-const": [
-            "error", {
+            "warn", {
                 "destructuring": "any",
                 "ignoreReadBeforeAssign": false
             }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -186,8 +186,10 @@ ${content}`
         );
       }
 
-      const header = this.template.header && `${this.template.header}\n`;
-      const footer = this.template.footer && `\n${this.template.footer}`;
+      const header =
+        this.template.header && `${this.template.header}${str.EOL}`;
+      const footer =
+        this.template.footer && `${str.EOL}${this.template.footer}`;
       const enclosedContent = str.append(
         str.prepend(replacedContent, header),
         footer

--- a/lib/string.js
+++ b/lib/string.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const EOL = require("os").EOL;
+
 exports.trimTrailing = (source, value) => {
   const regex = new RegExp(`\\${value}+$`);
   return source.replace(regex, "");
@@ -26,3 +28,5 @@ exports.keepSingle = (source, value) => {
 exports.merge = function() {
   return [].join.call(arguments, "");
 };
+
+exports.EOL = EOL;


### PR DESCRIPTION
* Included EditorConfig
* Set default JavaScript EOL's to LF
* Instead of hardcoding `\n` newline, used `os` modules `EOL` constant
* Loosened up on lint rule `prefer-const`

Should've been handled when fixing https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/54. Well, it got fixed now instead.

While working on newlines, also fixed issue https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/65.