### PR TITLE
Update mock-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "husky": "^0.14.3",
     "is-thirteen": "^2.0.0",
     "lint-staged": "^4.3.0",
-    "mock-fs": "^4.4.2",
+    "mock-fs": "^4.13.0",
     "nyc": "^11.3.0",
     "prettier": "^1.8.2",
     "webpack": "^4.41.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4154,9 +4154,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mock-fs@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.4.2.tgz#09dec5313f97095a450be6aa2ad8ab6738d63d6b"
+mock-fs@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.13.0.tgz#31c02263673ec3789f90eb7b6963676aa407a598"
+  integrity sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
When bumping Node.js to v10.13 file IO tests started to fail. This, backwards compatible, version fixes that.