### PR TITLE
Default assets for all JavaScript and CSS files

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const log = require("./logger").log;
 const tap = require("./tap");
 
 class Plugin {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,12 +6,13 @@ const tap = require("./tap");
 class Plugin {
   constructor(opts) {
     const options = opts || {
-      rules: []
+      rules: [
+        {
+          test: /\.(css|js)$/
+        }
+      ]
     };
-    if (!options.rules || !options.rules.length) {
-      log("No rules specified. No templated chunks will be outputted.");
-      log(options);
-    }
+
     this.pluginName = "TemplatedAssetsWebpackPlugin";
     this.pluginOptions = options;
   }

--- a/test/plugin-init-test.js
+++ b/test/plugin-init-test.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import Plugin from "../lib/plugin";
 
-test("fallback to rule set for all JavaScript and CSS files", (t) => {
+test("fallback to rule set for all JavaScript and CSS files", t => {
   const { rules } = new Plugin().pluginOptions;
   t.true(Array.isArray(rules));
   t.is(rules.length, 1);
@@ -12,7 +12,7 @@ test("fallback to rule set for all JavaScript and CSS files", (t) => {
   t.false(rule.test.test("an-svg-file.abc1234.svg"));
 });
 
-test("init rules", (t) => {
+test("init rules", t => {
   const { rules } = new Plugin({
     rules: [{ name: "an-entry" }]
   }).pluginOptions;

--- a/test/plugin-init-test.js
+++ b/test/plugin-init-test.js
@@ -1,13 +1,18 @@
 import test from "ava";
 import Plugin from "../lib/plugin";
 
-test("fallback to empty rule set", t => {
+test("fallback to rule set for all JavaScript and CSS files", (t) => {
   const { rules } = new Plugin().pluginOptions;
   t.true(Array.isArray(rules));
-  t.is(rules.length, 0);
+  t.is(rules.length, 1);
+  const rule = rules.pop();
+
+  t.true(rule.test.test("a-javascript-file.abc1234.js"));
+  t.true(rule.test.test("a-css-file.abc1234.css"));
+  t.false(rule.test.test("an-svg-file.abc1234.svg"));
 });
 
-test("init rules", t => {
+test("init rules", (t) => {
   const { rules } = new Plugin({
     rules: [{ name: "an-entry" }]
   }).pluginOptions;


### PR DESCRIPTION
Fix for https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/85.

Instead of creating templated assets for everything, default to JavaScript and CSS files.
