### PR TITLE
Default reference asset without path

### DIFF
--- a/lib/compiled-chunk.js
+++ b/lib/compiled-chunk.js
@@ -3,15 +3,17 @@
 const str = require("./string");
 
 class CompiledChunk {
-  constructor(name, filename, source, path) {
+  constructor(name, filename, source, path = "") {
     this.name = name;
     this.filename = filename;
     this.source = source;
-    this.path = path || "/";
+    this.path = path === "/" ? path : str.trimTrailing(path, "/");
   }
 
   get url() {
-    return `${str.trimTrailing(this.path, "/")}/${this.filename}`;
+    return this.path
+      ? `${str.trimTrailing(this.path, "/")}/${this.filename}`
+      : this.filename;
   }
 
   get keep() {

--- a/lib/public-path.js
+++ b/lib/public-path.js
@@ -1,7 +1,9 @@
-module.exports = compilation => {
+module.exports = (compilation, autoToEmpty) => {
   if (!compilation || !compilation.outputOptions) return "";
 
   const { publicPath } = compilation.outputOptions;
 
-  return publicPath !== undefined ? publicPath : "";
+  const path = publicPath || "";
+
+  return autoToEmpty && path === "auto" ? "" : path;
 };

--- a/lib/public-path.js
+++ b/lib/public-path.js
@@ -1,5 +1,7 @@
 module.exports = compilation => {
-  if (!compilation || !compilation.outputOptions) return "/";
+  if (!compilation || !compilation.outputOptions) return "";
 
-  return compilation.outputOptions.publicPath || "/";
+  const { publicPath } = compilation.outputOptions;
+
+  return publicPath !== undefined ? publicPath : "";
 };

--- a/lib/tap.js
+++ b/lib/tap.js
@@ -1,3 +1,4 @@
+const { version } = require("webpack");
 const { RawSource } = require("webpack-sources");
 
 const RuleSet = require("./rule-set");
@@ -11,7 +12,7 @@ function tap(options, compilation, callback) {
   const { chunks } = new CompiledChunks(
     compilation.chunks,
     compilation.assets,
-    publicPath(compilation)
+    publicPath(compilation, +version[0] >= 5)
   );
 
   new TemplatedAssets(chunks, rules)

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "webpack-sources": "^1.4.3"
   },
   "devDependencies": {
-    "ava": "^2.4.0",
     "@babel/core": "^7.11.6",
-    "babel-eslint": "^10.1.0",
-    "babel-loader": "^8.1.0",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.11.5",
+    "ava": "^2.4.0",
+    "babel-eslint": "^10.1.0",
+    "babel-loader": "^8.1.0",
     "css-loader": "^4.3.0",
     "escope": "^3.6.0",
     "eslint": "^7.9.0",
@@ -27,7 +27,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
-    "webpack": "^5.0.0-beta.30",
+    "webpack": "^5.0.0-rc.0",
     "webpack-cli": "^3.3.12"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "templated-assets-webpack-plugin",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "webpack plugin for creating assets to be used with server rendered web frameworks.",
   "main": "index.js",
   "dependencies": {

--- a/test/compiled-chunks-init-test.js
+++ b/test/compiled-chunks-init-test.js
@@ -58,14 +58,14 @@ test("map compiled chunks", t => {
   t.is(chunk1.name, expected1.name);
   t.is(chunk1.filename, expected1.files[0]);
   t.is(chunk1.source, compilation.assets[expected1.files[0]].source());
-  t.is(chunk1.path, "/");
-  t.is(chunk1.url, `/${expected1.files[0]}`);
+  t.is(chunk1.path, "");
+  t.is(chunk1.url, `${expected1.files[0]}`);
 
   t.is(chunk2.name, expected2.name);
   t.is(chunk2.filename, expected2.files[0]);
   t.is(chunk2.source, compilation.assets[expected2.files[0]].source());
-  t.is(chunk2.path, "/");
-  t.is(chunk2.url, `/${expected2.files[0]}`);
+  t.is(chunk2.path, "");
+  t.is(chunk2.url, `${expected2.files[0]}`);
 });
 
 test("include from assets", t => {
@@ -101,8 +101,8 @@ test("include from assets", t => {
 
   t.is(compiledChunks.chunks.length, 3);
   t.is(chunk.filename, "c.js");
-  t.is(chunk.path, "/");
-  t.is(chunk.url, "/c.js");
+  t.is(chunk.path, "");
+  t.is(chunk.url, "c.js");
   t.is(chunk.source, "contents of c.js");
 });
 
@@ -144,7 +144,7 @@ test("include public path for assets", t => {
   const compilation = {
     mainTemplate: {
       outputOptions: {
-        publicPath: "a public path"
+        publicPath: "a public path/"
       }
     },
     chunks: [],
@@ -167,4 +167,31 @@ test("include public path for assets", t => {
   t.is(chunk.source, "contents of a.css");
   t.is(chunk.path, "a public path");
   t.is(chunk.url, "a public path/a.css");
+});
+
+test("serve assets from root", t => {
+  const compilation = {
+    outputOptions: {
+      publicPath: "/"
+    },
+    chunks: [],
+    assets: {
+      "a.css": {
+        source: () => "contents of a.css"
+      }
+    }
+  };
+
+  const compiledChunks = new CompiledChunks(
+    compilation.chunks,
+    compilation.assets,
+    compilation.outputOptions.publicPath
+  );
+  const chunk = compiledChunks.chunks[0];
+
+  t.is(compiledChunks.chunks.length, 1);
+  t.is(chunk.filename, "a.css");
+  t.is(chunk.source, "contents of a.css");
+  t.is(chunk.path, "/");
+  t.is(chunk.url, "/a.css");
 });

--- a/test/plugin-apply-test.js
+++ b/test/plugin-apply-test.js
@@ -43,7 +43,7 @@ test.cb("emit url asset", t => {
       const [chunk] = compilation.chunks;
       const [file] = chunk.files;
 
-      const expected = `<script type="text/javascript" src="/${file}"></script>${EOL}`;
+      const expected = `<script type="text/javascript" src="${file}"></script>${EOL}`;
       const asset = compilation.assets["url-asset.html"];
       t.is(asset.size(), expected.length);
 
@@ -90,7 +90,7 @@ test.cb("emit async asset", t => {
       const [chunk] = compilation.chunks;
       const [file] = chunk.files;
 
-      const expected = `<script type="text/javascript" src="/${file}" async="async"></script>${EOL}`;
+      const expected = `<script type="text/javascript" src="${file}" async="async"></script>${EOL}`;
 
       const asset = compilation.assets["async-asset.html"];
       t.is(asset.size(), expected.length);
@@ -122,6 +122,7 @@ test.cb("emit deferred asset", t => {
         "deferred-asset": path.join(__dirname, "plugin-apply-test-entry.js")
       },
       output: {
+        publicPath: "/",
         path: OUTPUT_PATH
       },
       plugins: [plugin]
@@ -170,6 +171,7 @@ test.cb("emit async/defer asset", t => {
         "async-defer-asset": path.join(__dirname, "plugin-apply-test-entry.js")
       },
       output: {
+        publicPath: "a-public-path/",
         path: OUTPUT_PATH
       },
       plugins: [plugin]
@@ -185,7 +187,7 @@ test.cb("emit async/defer asset", t => {
       const [chunk] = compilation.chunks;
       const [file] = chunk.files;
 
-      const expected = `<script type="text/javascript" src="/${file}" async="async" defer="defer"></script>${EOL}`;
+      const expected = `<script type="text/javascript" src="a-public-path/${file}" async="async" defer="defer"></script>${EOL}`;
 
       const asset = compilation.assets["async-defer-asset.html"];
       t.is(asset.size(), expected.length);

--- a/test/public-path-test.js
+++ b/test/public-path-test.js
@@ -3,13 +3,19 @@ import test from "ava";
 import publicPath from "../lib/public-path";
 
 test("fallback public path", t => {
-  t.is(publicPath(), "/");
-  t.is(publicPath({}), "/");
+  t.is(publicPath(), "");
+  t.is(publicPath({}), "");
   t.is(
     publicPath({
       outputOptions: undefined
     }),
-    "/"
+    ""
+  );
+  t.is(
+    publicPath({
+      outputOptions: {}
+    }),
+    ""
   );
   t.is(
     publicPath({
@@ -17,7 +23,7 @@ test("fallback public path", t => {
         publicPath: undefined
       }
     }),
-    "/"
+    ""
   );
 });
 

--- a/test/public-path-test.js
+++ b/test/public-path-test.js
@@ -37,3 +37,28 @@ test("public path from output options", t => {
     "a path"
   );
 });
+
+test("default don't blank auto public path", t => {
+  t.is(
+    publicPath({
+      outputOptions: {
+        publicPath: "auto"
+      }
+    }),
+    "auto"
+  );
+});
+
+test("blank auto public path", t => {
+  t.is(
+    publicPath(
+      {
+        outputOptions: {
+          publicPath: "auto"
+        }
+      },
+      true
+    ),
+    ""
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,14 +2233,6 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@5.0.0-beta.10:
-  version "5.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.10.tgz#3907c034f8e59446dfa5a89a1fd73db29aa0f246"
-  integrity sha512-vEyxvHv3f8xl7i7QmTQ6BqKY32acSPQ4dTZo8WRMtcqTDYH9YyXnDxqXsQqBLvdRHUiwl9nVivESiM1RcrxbKQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    tapable "^2.0.0-beta.10"
-
 enhanced-resolve@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
@@ -2249,6 +2241,14 @@ enhanced-resolve@^4.1.1:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
+
+enhanced-resolve@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0.tgz#4737e6ebd4f2fd13fe23f4cec9d02146afc2c527"
+  integrity sha512-6F037vvK16tgLlRgUx6ZEZISMysNvnnk09SILFrx3bNa1UsSLpIXFzWOmtiDxf1ISPAG6/wHBI61PEkeuTLVNA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.0.0"
 
 enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
@@ -2943,7 +2943,7 @@ graceful-fs@^4.1.11:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-graceful-fs@^4.1.15, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.15, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -5522,10 +5522,10 @@ tapable@^1.0.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tapable@^2.0.0-beta.10, tapable@^2.0.0-beta.11:
-  version "2.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.0.0-beta.11.tgz#5a6bd5e0353fad4da9e94942206bb596639e8cf7"
-  integrity sha512-cAhRzCvMdyJsxmdrSXG8/SUlJG4WJUxD/csuYAybUFjKVt74Y6pTyZ/I1ZK+enmCkWZN0JWxh14G69temaGSiA==
+tapable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.0.0.tgz#a49c3d6a8a2bb606e7db372b82904c970d537a08"
+  integrity sha512-bjzn0C0RWoffnNdTzNi7rNDhs1Zlwk2tRXgk8EiHKAOX1Mag3d6T0Y5zNa7l9CJ+EoUne/0UHdwS8tMbkh9zDg==
 
 tar@^6.0.2:
   version "6.0.5"
@@ -5821,10 +5821,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-watchpack@2.0.0-beta.15:
-  version "2.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.0.0-beta.15.tgz#0e69c8e5d680c7b4c181db3f70e500ca84cef794"
-  integrity sha512-zyhhC7vEajo5fZEUxlhVpC1uLAOs088zy8RwzcMp8YucTBirNCNmTFQWVeoKxKNNqEfYUBQdVzW3wfItcc/eUQ==
+watchpack@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.0.0.tgz#b12248f32f0fd4799b7be0802ad1f6573a45955c"
+  integrity sha512-xSdCxxYZWNk3VK13bZRYhsQpfa8Vg63zXG+3pyU8ouqSLRCv4IGXIp9Kr226q6GBkGRlZrST2wwKtjfKz2m7Cg==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
@@ -5853,14 +5853,6 @@ webpack-cli@^3.3.12:
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
 
-webpack-sources@2.0.0-beta.10:
-  version "2.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.0.0-beta.10.tgz#f603355c5518141976601bfd620a3a5a01ac7b5d"
-  integrity sha512-HxeYa9Q6nMk3MtSbi5mKUUV+gOxYlGQwujKbeK0JQ+SmLSMgC4cQkZ+xpsWvsUtTvskDwpKvuVLpE9eW7vn0IQ==
-  dependencies:
-    source-list-map "^2.0.1"
-    source-map "^0.6.1"
-
 webpack-sources@^1.1.0, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -5869,10 +5861,18 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^5.0.0-beta.30:
-  version "5.0.0-beta.30"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-beta.30.tgz#11cf2d4ed1ec78eb836da2a7be7809e5e074e3eb"
-  integrity sha512-pOAAo71m6icygRrOPn/lQM4Ky8MN+9dDBwEU9Get285VBbmuZE6AFqizEEV692mYgUit/0+7vnjsnUr8xX2puA==
+webpack-sources@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.0.0.tgz#602d4bc7ff2e630ceb753a09ef49f260fa4ae7f0"
+  integrity sha512-CpCkDjEKa5vYVRDFDRABBkBomz+82lz9bpXViN1LBc8L/WDXvSyELKcBvBnTeDEiRfMJCGAFG9+04406PLSsIA==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
+
+webpack@^5.0.0-rc.0:
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-rc.0.tgz#166f6d9cd65912ff021695d82256b2f1e6e858ee"
+  integrity sha512-tHUFu4vaZxJuyKYf8FKkDZmxnf0txy6twNewxUlviFo+GYjFoGW3szD71cOw0NtJBiyGAQ9zLGVzfb2pXBSKVA==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.45"
@@ -5882,7 +5882,7 @@ webpack@^5.0.0-beta.30:
     "@webassemblyjs/wasm-parser" "1.9.0"
     acorn "^7.4.0"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "5.0.0-beta.10"
+    enhanced-resolve "^5.0.0"
     eslint-scope "^5.1.0"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
@@ -5893,10 +5893,10 @@ webpack@^5.0.0-beta.30:
     neo-async "^2.6.2"
     pkg-dir "^4.2.0"
     schema-utils "^2.7.0"
-    tapable "^2.0.0-beta.11"
+    tapable "^2.0.0"
     terser-webpack-plugin "^4.1.0"
-    watchpack "2.0.0-beta.15"
-    webpack-sources "2.0.0-beta.10"
+    watchpack "^2.0.0"
+    webpack-sources "^2.0.0"
 
 well-known-symbols@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fix https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/108.

**Breaking change**
webpack 5:
- `""` or `"auto"` as `publicPath` will generate asset references with only filename

webpack 3-4:
- will preserve "auto" as a folder
- `publicPath: ""` generates asset reference with only filename

webpack@5 defaults `publicPath` to `"auto"`. The generated templated assets cannot reference with auto as path, because a browser would treat `auto` as a folder.

When looking into the issue, it became apparent that `templated-assets-webpack-plugin`'s default behaviour for asset paths was buggy. Without specifying `publicPath` (or a blank value) the asset was expected to be served from root.