### PR TITLE
Ensure value before comparing version

### DIFF
--- a/lib/tap.js
+++ b/lib/tap.js
@@ -7,12 +7,14 @@ const publicPath = require("./public-path");
 const TemplatedAssets = require("./templated-assets");
 const { log } = require("./logger");
 
+const webpackVersion = version && +version[0];
+
 function tap(options, compilation, callback) {
   const rules = RuleSet.from(options.rules);
   const { chunks } = new CompiledChunks(
     compilation.chunks,
     compilation.assets,
-    publicPath(compilation, +version[0] >= 5)
+    publicPath(compilation, webpackVersion >= 5)
   );
 
   new TemplatedAssets(chunks, rules)


### PR DESCRIPTION
When trying to detect version for older versions of webpack, version check failed. Added to handle this:
https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/108#issuecomment-696893883

This fix corrects the version check.