### PR TITLE
Integration tests for webpack@2 passes, so yolo

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^4.0.0"
   },
   "peerDependencies": {
-    "webpack": "^3.0.0 || ^4.0.0 || ^5.0.0"
+    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=10.13.0"


### PR DESCRIPTION
Tests are run for webpack@2-5, so let's hint webpack@2 is supported.

Let's call this one fixed https://github.com/jouni-kantola/templated-assets-webpack-plugin/issues/107